### PR TITLE
[WIP]bmx7: add wireguard plugin

### DIFF
--- a/bmx7/Makefile
+++ b/bmx7/Makefile
@@ -47,6 +47,11 @@ define Package/bmx7
   MENU:=1
 endef
 
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	$(CP) $(PKG_BUILD_DIR)/src/* $(PKG_BUILD_DIR)/
+endef
+
 define Package/bmx7-uci-config
   $(call Package/bmx7/Default)
   DEPENDS:=bmx7 +libuci
@@ -81,6 +86,12 @@ define Package/bmx7-tun
   $(call Package/bmx7/Default)
   DEPENDS:=bmx7 +kmod-ip6-tunnel +kmod-iptunnel6 +kmod-tun
   TITLE:=ipip-based tunnel plugin (recommended!)
+endef
+
+define Package/bmx7-wg-tun
+  $(call Package/bmx7/Default)
+  DEPENDS:=bmx7
+  TITLE:=wireguard-based tunnel plugin
 endef
 
 define Package/bmx7-table
@@ -150,6 +161,11 @@ define Package/bmx7-tun/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lib/bmx7_tun/bmx7_tun.so $(1)/usr/lib/bmx7_tun.so
 endef
 
+define Package/bmx7-wg-tun/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lib/bmx7_wg_tun/bmx7_wg_tun.so $(1)/usr/lib/bmx7_wg_tun.so
+endef
+
 define Package/bmx7-table/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lib/bmx7_table/bmx7_table.so $(1)/usr/lib/bmx7_table.so
@@ -163,3 +179,4 @@ $(eval $(call BuildPackage,bmx7-json))
 $(eval $(call BuildPackage,bmx7-sms))
 $(eval $(call BuildPackage,bmx7-table))
 $(eval $(call BuildPackage,bmx7-tun))
+$(eval $(call BuildPackage,bmx7-wg-tun))

--- a/bmx7/files/etc/config/bmx7
+++ b/bmx7/files/etc/config/bmx7
@@ -26,6 +26,9 @@ config 'dev' 'mesh_2'
 
 #config 'plugin'
 #        option 'plugin' 'bmx7_tun.so'
+#
+#config 'plugin'
+#        option 'plugin' 'bmx7_wg_tun.so'
 
 #config 'plugin'
 #        option 'plugin' 'bmx7_table.so'


### PR DESCRIPTION
BMX7 now support wireguard tunnels via a new plugin[0].

[0]: bmx-routing/bmx7#52

Signed-off-by: Paul Spooren <mail@aparcar.org>