### PR TITLE
issuetemplate: reference foreign repos

### DIFF
--- a/.github/issue_template
+++ b/.github/issue_template
@@ -1,6 +1,6 @@
 Please make sure that the issue subject starts with `<package-name>: `
 
-Also make sure that the package is maintained in this repository and not in base which should be submitted at https://bugs.openwrt.org or in the LuCI repository which should be submitted at https://github.com/openwrt/luci/issues.
+Also make sure that the package is maintained in this repository and not in OpenWrt-base, OpenWrt-packages or OpenWrt-LuCI.
 
 Issues related to releases below 18.06 and forks are not supported or maintained and will be closed.
 


### PR DESCRIPTION
As we are the routing-feed, we don't care for packages of the base-, luci- and packages-feed.
So update the imported issue-tempalte accordingly 