### PR TITLE
olsrd: add olsrd-neigh.sh

### DIFF
--- a/olsrd/Makefile
+++ b/olsrd/Makefile
@@ -157,6 +157,12 @@ define Package/olsrd-mod-watchdog
   TITLE:=Watchdog plugin
 endef
 
+define Package/olsrd-utils
+  $(call Package/olsrd/template)
+  DEPENDS:=olsrd
+  TITLE:=Utils for OLSRD
+endef
+
 define Package/olsrd-mod-pud/conffiles
 /etc/olsrd.d/olsrd.pud.position.conf
 endef
@@ -298,6 +304,11 @@ define Package/olsrd-mod-watchdog/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lib/watchdog/olsrd_watchdog.so.* $(1)/usr/lib/
 endef
 
+define Package/olsrd-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) ./files/olsrd-neigh.sh $(1)/usr/bin/olsrd-neigh
+endef
+
 $(eval $(call BuildPackage,olsrd))
 $(eval $(call BuildPackage,olsrd-mod-arprefresh))
 $(eval $(call BuildPackage,olsrd-mod-dot-draw))
@@ -318,3 +329,4 @@ $(eval $(call BuildPackage,olsrd-mod-secure))
 $(eval $(call BuildPackage,olsrd-mod-sgwdynspeed))
 $(eval $(call BuildPackage,olsrd-mod-txtinfo))
 $(eval $(call BuildPackage,olsrd-mod-watchdog))
+$(eval $(call BuildPackage,olsrd-utils))

--- a/olsrd/files/olsrd-neigh.sh
+++ b/olsrd/files/olsrd-neigh.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+
+. /usr/share/libubox/jshn.sh
+
+hostsfile_getname()
+{
+	local config="$1"
+	local i=0
+	local value file
+
+	while value="$( uci -q get $config.@LoadPlugin[$i].library )"; do {
+		case "$value" in
+			'olsrd_nameservice'*)
+				file="$( uci -q get $config.@LoadPlugin[$i].hosts_file )"
+				break
+			;;
+		esac
+
+		i=$(( i + 1 ))
+	} done
+
+	echo "${file:-/var/run/hosts_olsr}"
+}
+
+read_hostnames()
+{
+	local file_list=" $( hostsfile_getname 'olsrd' ) $(hostsfile_getname 'olsrd6' ) "
+	local line ip hostname file file_list_uniq
+
+	for file in $file_list; do {
+		case " $file_list_uniq " in
+			*" $file "*)
+			;;
+			*)
+				file_list_uniq="$file_list_uniq $file"
+			;;
+		esac
+	} done
+
+	for file in $file_list_uniq; do {
+		[ -e "$file" ] || continue
+
+		while read -r line; do {
+			case "$line" in
+				[0-9]*)
+					# 2001:ffff:ffff:ffff::1 SomeNode-core.olsr   # myself
+					# 10.0.0.1  SomeNode    # 10.0.0.1
+					set -f
+					set +f -- $line
+					ip="$1"
+					hostname="$2"
+
+					# global vars, e.g.
+					# IP_1_2_3_4='foo' or IP_2001_ffff_ffff_ffff__1='bar'
+					eval IP_${ip//[.:]/_}="$hostname"
+				;;
+			esac
+		} done <"$file"
+	} done
+}
+
+read_hostnames
+
+VARS='localIP:Local remoteIP:Remote validityTime:vTime linkQuality:LQ'
+VARS="$VARS neighborLinkQuality:NLQ linkCost:Cost remoteHostname:Host"
+
+for HOST in '127.0.0.1' '::1';do
+	# check for availability of HOST
+	nc $HOST 9090 >/dev/null 2>&1
+	if [ $? != 0 ]; then
+		continue
+	fi
+
+	json_init
+	json_load "$( echo /links | nc $HOST 9090 | sed -n '/^[}{ ]/p' )"	# remove header/non-json
+
+	if json_is_a links array;then
+		json_select links
+		for v in ${VARS};do
+			eval _${v%:*}=0
+		done
+		for j in 0 1;do
+			case ${j} in 1)
+				for v in ${VARS};do
+					eval printf \"%-\${_${v%:*}}s \" ${v#*:}
+				done
+				echo
+			;;esac
+			i=1;while json_is_a ${i} object;do
+				json_select ${i}
+				json_get_vars $(for v in ${VARS};do echo ${v%:*};done)
+				case ${j} in 0)
+					for v in ${VARS};do
+						eval "test \${_${v%:*}} -lt \${#${v%:*}} && _${v%:*}=\${#${v%:*}}"
+					done
+				;;*)
+					for v in ${VARS};do
+						eval printf \"%-\${_${v%:*}}s \" \$${v%:*}
+						eval remoteHostname="\$IP_${remoteIP//[.:]/_}"
+					done
+					echo
+				;;esac
+				json_select ..
+				i=$(( i + 1 ))
+			done
+		done
+	fi
+	echo
+done


### PR DESCRIPTION
This script originates from Freifunk Berlin. It prints a list of
all meshing neighbors known to olsrd on the command line.

Signed-off-by: Martin Hübner <martin.hubner@web.de>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
