### PR TITLE
opennds: Release v9.1.0

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=9.0.0
+PKG_VERSION:=9.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=opennds-$(PKG_VERSION).tar.gz
-PKG_HASH:=466dbd78a9464d56f6bf8c8374071e4c21854700a8176a47e72e23930e4271b2
+PKG_HASH:=6064b906b820fb960b15321e83708bd074e1bb797f7741d73740802ad94f7b0c
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>


### PR DESCRIPTION
Maintainer: Rob White <rob@blue-wave.net>
Compile tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc
Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, gl-inet b1300, gl-inet mt300n-v2, Snapshot, 21.02.0-rc3, 19.07.7

Description:
This version introduces new functionality, some changes and fixes
Tested on OpenWrt, OpenSuse and Debian.

From the Changelog:
  * Add - option statuspath to enable alternate status page scripts [bluewavenet]
  * Add - ndsctl lockf() file locking [bluewavenet] [T-X]
  * Add - b64encode to ndsctl [bluewavenet]
  * Add - option max_page_size for MHD [bluewavenet]
  * Add - option remotes_refresh_interval [bluewavenet]
  * Add - Pre-download remote files in background after startup [bluewavenet]
  * Add - client id data files created by openNDS on client connect [bluewavenet]
  * Add - check routing is configured and up [bluewavenet]
  * Add - support for Preemptive Authentication for connected client devices. [bluewavenet]
  * Add - Gateway interface watchdog [bluewavenet]
  * Remove - deprecated IFB config [bluewavenet]
  * Fix - ndsctl, send return codes [bluewavenet]
  * Fix - MHD Watchdog Use uclient-fetch in OpenWrt [bluewavenet]
  * Fix - Improve MHD watchdog [bluewavenet]
  * Fix - update legacy code in ndsctl_thread [bluewavenet]
  * Fix - edge case where MHD returns (null) as host value [bluewavenet]

Signed-off-by: `Rob White <rob@blue-wave.net>`