### PR TITLE
opennds: Release v9.1.1

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=9.0.0
+PKG_VERSION:=9.1.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=opennds-$(PKG_VERSION).tar.gz
-PKG_HASH:=466dbd78a9464d56f6bf8c8374071e4c21854700a8176a47e72e23930e4271b2
+PKG_HASH:=1dbc3e11412ef55ccb73d996599dd33a22fe5c67571e879445a0c6699ae6862b
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>


### PR DESCRIPTION
Maintainer: Rob White rob@blue-wave.net
Compile tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc
Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, gl-inet b1300, gl-inet mt300n-v2, Snapshot, 21.02.0-rc3, 19.07.7

Description:
This version fixes a compiler error, some compiler warnings and mutes a debug message
  * Fix - Compiler error, missing mode in call to open() [bluewave.net]
  * Fix - Compiler warning, ignored return value from call to lockf() [bluewave.net]
  * Fix - Compiler warning, ignored return value from call to system() [bluewave.net]
  * Fix - Compiler warning, ignored return value from call to fgets() [bluewave.net]
  * Fix - Remove debug message from call to get_client_interface library [bluewave.net]

Signed-off-by: Rob White <rob@blue-wave.net>
