### PR TITLE
[21.02] olsrd: fix olsrd starting before network

### DIFF
--- a/olsrd/files/olsrd4.init
+++ b/olsrd/files/olsrd4.init
@@ -10,6 +10,18 @@ OLSRD=olsrd
 CONF=/var/etc/$OLSRD.conf
 PID=/var/run/olsrd.pid
 
+wait_for_network()
+{
+	ubus -t 15 wait_for network.interface.$1 2>/dev/null
+}
+
+boot()
+{
+	config_load network
+	config_foreach wait_for_network interface
+	rc_procd start_service
+}
+
 start_service() {
 	olsrd_generate_config $OLSRD
 	

--- a/olsrd/files/olsrd6.init
+++ b/olsrd/files/olsrd6.init
@@ -10,6 +10,17 @@ OLSRD=olsrd6
 CONF=/var/etc/$OLSRD.conf
 PID=/var/run/olsrd6.pid
 
+wait_for_network()
+{
+	ubus -t 15 wait_for network.interface.$1 2>/dev/null
+}
+
+boot()
+{
+	config_load network
+	config_foreach wait_for_network interface
+	rc_procd start_service
+}
 
 start_service() {
 	olsrd_generate_config $OLSRD


### PR DESCRIPTION
**Urgent fix so cherry-pick also in 21.02**

Should fix #691.

Sometimes the wifi interface is not ready before olsrd tries to access
it. This leads to warnings in the form of:

daemon.info olsrd: /etc/rc.d/S65olsrd: olsrd_write_interface()
	Warning: Interface 'wireless0' not found, skipped
daemon.notice procd: /etc/rc.d/S65olsrd: olsrd: /etc/rc.d/S65olsrd:
	olsrd_write_interface() Warning: Interface 'wireless0' not found,			skipped

We make use of the "wait_for" procd command that allows us to wait for
the network before starting olsrd.