### PR TITLE
olsrd: improve respawn settings

### DIFF
--- a/olsrd/files/olsrd.config
+++ b/olsrd/files/olsrd.config
@@ -22,3 +22,7 @@ config LoadPlugin
 
 config Interface
 	list interface 'wlan'
+
+config procd general
+	option respawn_timeout '15'
+	option respawn_retry '0'

--- a/olsrd/files/olsrd4.init
+++ b/olsrd/files/olsrd4.init
@@ -24,15 +24,23 @@ boot()
 
 start_service() {
 	olsrd_generate_config $OLSRD
-	
+
 	procd_open_instance
+
+	config_load olsrd
+	local _respawn_timeout
+	local _respawn_retry
+	
+	config_get _respawn_timeout general respawn_timeout	
+	config_get _respawn_retry general respawn_retry		
+	
 	procd_set_param command "$BIN"
 	procd_append_param command -f ${CONF}
 	procd_append_param command -nofork
 	procd_append_param command -pidfile ${PID}
 
 	# restart if olsrd dies
-	procd_set_param respawn
+	procd_set_param respawn 3600 $_respawn_timeout $_respawn_retry
 
 	# automatically restart olsrd if generated cfg has changed
 	procd_set_param file $CONF

--- a/olsrd/files/olsrd6.config
+++ b/olsrd/files/olsrd6.config
@@ -9,3 +9,7 @@ config LoadPlugin
 
 config Interface
 	list interface 'wlan'
+
+config procd general
+	option respawn_timeout '15'
+	option respawn_retry '0'

--- a/olsrd/files/olsrd6.init
+++ b/olsrd/files/olsrd6.init
@@ -26,13 +26,21 @@ start_service() {
 	olsrd_generate_config $OLSRD
 
 	procd_open_instance
+
+	config_load olsrd6
+	local _respawn_timeout
+	local _respawn_retry
+
+	config_get _respawn_timeout general respawn_timeout	
+	config_get _respawn_retry general respawn_retry			
+
 	procd_set_param command "$BIN"
 	procd_append_param command -f ${CONF}
 	procd_append_param command -nofork
 	procd_append_param command -pidfile ${PID}
 
 	# restart if olsrd dies
-	procd_set_param respawn
+	procd_set_param respawn 3600 $_respawn_timeout $_respawn_retry
 
 	# automatically restart olsrd if generated cfg has changed
 	procd_set_param file $CONF


### PR DESCRIPTION
This increases the amount of seconds to wait before a service restart attempt from 5 to 15 seconds and allows unlimited retries. Olsrd sometimes crashes together with a network interface and 5 seconds can be too short to bring back up a crashed network interface, which is required for olsrd to restart.

Signed-off-by: Tobias Schwarz <info@tobias-schwarz.com>