### PR TITLE
opennds: [21.02] Backport of Release v9.2.0

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=9.1.1
+PKG_VERSION:=9.2.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=opennds-$(PKG_VERSION).tar.gz
-PKG_HASH:=1dbc3e11412ef55ccb73d996599dd33a22fe5c67571e879445a0c6699ae6862b
+PKG_HASH:=6cfc65bae355f13a903e17094dbeafb0f6f8d26a446735b044961659766de0a9
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>


### PR DESCRIPTION
Maintainer: Rob White rob@blue-wave.net
Compile tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc
Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, gl-inet b1300, gl-inet mt300n-v2, Snapshot, 21.02.0-rc3, 19.07.7

Description:
This version adds new functionality, improves performance, adds documentation and fixes an issue
  * Add - new config options to ndsctl status [bluewave.net]
  * Add - Readthedocs / man documentation for configuration options [bluewave.net]
  * Add - Faster convergence of average rates to configured rate quotas [bluewave.net]
  * Add - BinAuth parse authenticated client database for client data [bluewave.net]
  * Add - Use heap allocation for http page buffer allowing large page sizes [bluewave.net]
  * Fix - fail to serve downloaded images on custom themespec [bluewave.net]

Signed-off-by: Rob White <rob@blue-wave.net>
