### PR TITLE
opennds: Release v9.3.0

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=9.2.0
+PKG_VERSION:=9.3.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=opennds-$(PKG_VERSION).tar.gz
-PKG_HASH:=6cfc65bae355f13a903e17094dbeafb0f6f8d26a446735b044961659766de0a9
+PKG_HASH:=719e128c4f08af4ad1924f8f1b1b63262c16e10f63b390a4c5c394cfc232aa20
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>


### PR DESCRIPTION
Maintainer: Rob White rob@blue-wave.net
Compile tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc
Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, gl-inet b1300, gl-inet mt300n-v2, Snapshot, 21.02.0-rc3, 19.07.7

Description:
This version adds new functionality, and fixes some issues
  * Add - firewall passthrough mode for authenticated users [bluewave.net]
  * Add - use configured debuglevel in authmon [bluewave.net]
  * Add - automated log rotation and client_zone to binauth_log [bluewave.net]
  * Add - increased timeout interval for file downloads [bluewave.net]
  * Add - local interface to MeshZone and remove unneeded call to ip utility [bluewave.net]
  * Add - log_mountpoint and max_log_entries options [bluewave.net]
  * Add - config variables ext_interface and ext_gateway [bluewave.net]
  * Add - Start initial download of remotes only if online [bluewave.net]
  * Add - Router online/offline watchdog [bluewave.net]
  * Fix - Segfault when gatewayfqdn is disabled [bluewave.net]
  * Fix - missing clientmac when not using themespec [bluewave.net]
  * Fix - some compiler warnings [bluewave.net]
  * Fix - use configured value for webroot for remote image symlink to images folder [bluewave.net]
  * Fix - remove refrences to login.sh in documentation and comments [bluewave.net]
  * Fix - Prevent potential read overrun within the MHD page buffer [bluewave.net]
  * Remove - legacy get_ext_iface() function [bluewave.net]

Signed-off-by: Rob White <rob@blue-wave.net>
