### PR TITLE
[master] bird2: Fix bus error on OSPF on IPQ806X

### DIFF
--- a/bird2/Makefile
+++ b/bird2/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird2
 PKG_VERSION:=2.0.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://bird.network.cz/pub/bird

--- a/bird2/patches/000-ospf-bus-error.patch
+++ b/bird2/patches/000-ospf-bus-error.patch
@@ -1,0 +1,11 @@
+--- a/proto/ospf/topology.h
++++ b/proto/ospf/topology.h
+@@ -41,7 +41,7 @@ struct top_hash_entry
+   u8 mode;			/* LSA generated during RT calculation (LSA_RTCALC or LSA_STALE)*/
+   u8 nhs_reuse;			/* Whether nhs nodes can be reused during merging.
+ 				   See a note in rt.c:add_cand() */
+-};
++} PACKED;
+ 
+ 
+ /* Prevents ospf_hash_find() to ignore the entry, for p->lsrqh and p->lsrth */


### PR DESCRIPTION
Maintainer: @tohojo 
Compile tested: IPQ806X, Netgear Nighthawk X4S R7800, master
Run tested: IPQ806X, Netgear Nighthawk X4S R7800, master. Bird2 now starts when OSPF v2 or v3 is configured.

Description:

On a Netgear R7800, if ospf v2 or v3 is configured in bird.conf, it fails to start with this error:

Fri Jun 11 14:41:11 2021 daemon.info bird: Started
Fri Jun 11 14:41:11 2021 kern.err kernel: [ 3500.853248] Alignment trap: not handling instruction f44c0a1f at [<00035848>] Fri Jun 11 14:41:11 2021 kern.alert kernel: [ 3500.853283] 8<--- cut here ---
Fri Jun 11 14:41:11 2021 kern.alert kernel: [ 3500.859363] Unhandled fault: alignment exception (0x801) at 0x007e0624
Fri Jun 11 14:41:11 2021 kern.alert kernel: [ 3500.862443] pgd = 0bbef4fd
Fri Jun 11 14:41:11 2021 kern.alert kernel: [ 3500.868821] [007e0624] *pgd=5d6ca835, *pte=5c40b75f, *ppte=5c40bc7f

The problem is due to a struct not being properly aligned on the ARMv7 architecture.

This patch fixes the problem by adding the "PACKED" macro to the affected struct. Note
that upstream may later fix this in another way, in which case this patch will not be required.

This is a forward port of the same fix in 21.02 in PR #712, reported in issue #679 

Signed-off-by: Matt Reeve <matt@mreeve.com>
(cherry picked from commit 166b6ea77b30f82eb880ce43a9e9ff343b79fe2e)

