### PR TITLE
cjdns: fix uci-defaults

### DIFF
--- a/cjdns/Makefile
+++ b/cjdns/Makefile
@@ -18,7 +18,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cjdns
 PKG_VERSION:=v21
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cjdelisle/cjdns/tar.gz/$(PKG_NAME)-$(PKG_VERSION)?

--- a/cjdns/files/cjdns.defaults
+++ b/cjdns/files/cjdns.defaults
@@ -23,17 +23,10 @@ EOF
   fi
 
   # enable auto-peering on ethernet interface lan, if existing
-  uci get network.lan | grep interface >/dev/null 2>&1
-  if [ $? -eq 0 ]; then
-    uci get network.lan.type | grep bridge >/dev/null 2>&1
-    if [ $? -eq 0 ]; then
-      # most routers will set up an ethernet bridge for the lan
-      ifname="br-lan"
-    else
-      # docker containers don't have permission to create bridges by default,
-      # so we bind to the underlying interface instead (likely eth0)
-      ifname=`uci get network.lan.ifname`
-    fi
+  ifname=$(uci -q get network.lan.device || \
+           ([ "$(uci -q get network.lan.type)" == "bridge" ] && echo br-lan) || \
+           uci -q get network.lan.ifname)
+  if [ -n "$ifname" ]; then
     uci -q batch <<-EOF >/dev/null
       add cjdns eth_interface
       set cjdns.@eth_interface[-1].beacon=2
@@ -46,7 +39,7 @@ EOF
   # create the network interface
   uci -q batch <<-EOF >/dev/null
     set network.cjdns=interface
-    set network.cjdns.ifname=tuncjdns
+    set network.cjdns.device=tuncjdns
     set network.cjdns.proto=none
 EOF
 


### PR DESCRIPTION
Maintainer: @wfleurant 
Environment: master / 21.02
Compile tested: NO
Run tested: NO
Description:

Since https://git.openwrt.org/?p=openwrt/openwrt.git;a=commitdiff;h=4b9a67362d70c544b85078b8d5c661f43f7472d9,
uci network config interface sections use 'device' instead of 'ifname'

Even if 'device' seems to always be set by
package/base-files/files/bin/config_generate, we keep the fallbacks
in case someone install the package via opkg and has a non migrated
network config
