### PR TITLE
batman-adv: Fix build against kernel 5.10

### DIFF
--- a/batman-adv/src/compat-hacks.h
+++ b/batman-adv/src/compat-hacks.h
@@ -51,6 +51,7 @@ inline void __batadv_br_ip_list_check(void)
 
 #if LINUX_VERSION_IS_LESS(5, 14, 0)
 
+#include <linux/if_bridge.h>
 #include <net/addrconf.h>
 
 #if IS_ENABLED(CONFIG_IPV6)


### PR DESCRIPTION
Maintainer: @simonwunderlich 
Compile tested: x86
Run tested: qemu-system-x86_64


The linux kernel 5.10 needs an explicit include of linux/if_bridge.h to  define br_multicast_list_adjacent and the struct br_ip_list. Otherwise the build fails with:

````
  CC [M]  /home/sven/tmp/openwrt/build_dir/target-i386_pentium4_musl/linux-x86_generic/batman-adv-2021.2/net/batman-adv/bat_algo.o
In file included from <command-line>:
/home/sven/tmp/openwrt/build_dir/target-i386_pentium4_musl/linux-x86_generic/batman-adv-2021.2/compat-hacks.h: In function 'br_multicast_has_router_adjacent':
/home/sven/tmp/openwrt/build_dir/target-i386_pentium4_musl/linux-x86_generic/batman-adv-2021.2/compat-hacks.h:67:8: error: implicit declaration of function 'br_multicast_list_adjacent'; did you mean 'br_multicast_has_router_adjacent'? [-Werror=implicit-function-declaration]
   67 |  ret = br_multicast_list_adjacent(dev, &bridge_mcast_list);
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |        br_multicast_has_router_adjacent
In file included from ./include/uapi/linux/stddef.h:2,
                 from ./include/linux/stddef.h:5,
                 from /home/sven/tmp/openwrt/staging_dir/target-i386_pentium4_musl/usr/include/mac80211-backport/linux/stddef.h:3,
                 from ./include/uapi/linux/posix_types.h:5,
                 from ./include/uapi/linux/types.h:14,
                 from ./include/linux/types.h:6,
                 from /home/sven/tmp/openwrt/staging_dir/target-i386_pentium4_musl/usr/include/mac80211-backport/linux/types.h:4,
                 from /home/sven/tmp/openwrt/build_dir/target-i386_pentium4_musl/linux-x86_generic/batman-adv-2021.2/compat-hacks.h:6,
                 from <command-line>:
./include/linux/kernel.h:853:51: error: invalid use of undefined type 'struct br_ip_list'
  853 |  BUILD_BUG_ON_MSG(!__same_type(*(ptr), ((type *)0)->member) && \
      |
````

Reported-by: @neheb 