### PR TITLE
batman-adv: update packages to version 2021.3

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alfred
-PKG_VERSION:=2021.2
+PKG_VERSION:=2021.3
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=bd6a21ca270d56671c6d69f4fed9aa1faf3226beead9a5b9ef2aaabcda61da66
+PKG_HASH:=be6229edf2a3e9cf69122e5283d113e9405f1455e8fd4ebd55294e9bf9157b5a
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
 PKG_LICENSE:=GPL-2.0-only MIT

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
-PKG_VERSION:=2021.2
+PKG_VERSION:=2021.3
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=1af753f9209fabaec5b2ab36ffdb1b8ed5fc7b847a126e6271930b3e6ad1c47b
+PKG_HASH:=f22f4befc28f8a4609f1f8403b4c40ea01b83e4f9448453e2bbae3db7b47fc20
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
-PKG_VERSION:=2021.2
+PKG_VERSION:=2021.3
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=7a380a193b543b0cd1e30bb697f03d967776192ca0ebd2e433a63ad48ff26d8b
+PKG_HASH:=b24deec9baee786ca91085e32f7e09d4cc94f965ae71c9560895f82ec1cc906b
 PKG_EXTMOD_SUBDIRS:=net/batman-adv
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/patches/0001-Revert-batman-adv-genetlink-move-to-smaller-ops-wher.patch
+++ b/batman-adv/patches/0001-Revert-batman-adv-genetlink-move-to-smaller-ops-wher.patch
@@ -106,7 +106,7 @@ This reverts commit 725b4ef5be840cfcd0ca33b9393c14dee40c10f7.
  #endif /* _NET_BATMAN_ADV_COMPAT_NET_GENETLINK_H_ */
 --- a/net/batman-adv/netlink.c
 +++ b/net/batman-adv/netlink.c
-@@ -1359,7 +1359,7 @@ static void batadv_post_doit(const struc
+@@ -1357,7 +1357,7 @@ static void batadv_post_doit(const struc
  	}
  }
  
@@ -115,7 +115,7 @@ This reverts commit 725b4ef5be840cfcd0ca33b9393c14dee40c10f7.
  	{
  		.cmd = BATADV_CMD_GET_MESH,
  		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
-@@ -1493,8 +1493,8 @@ struct genl_family batadv_netlink_family
+@@ -1491,8 +1491,8 @@ struct genl_family batadv_netlink_family
  	.pre_doit = batadv_pre_doit,
  	.post_doit = batadv_post_doit,
  	.module = THIS_MODULE,

--- a/batman-adv/patches/0003-batman-adv-Fix-build-of-multicast-code-against-Linux.patch
+++ b/batman-adv/patches/0003-batman-adv-Fix-build-of-multicast-code-against-Linux.patch
@@ -7,7 +7,7 @@ Signed-off-by: Sven Eckelmann <sven@narfation.org>
 
 --- a/net/batman-adv/multicast.c
 +++ b/net/batman-adv/multicast.c
-@@ -423,9 +423,14 @@ batadv_mcast_mla_softif_get_ipv6(struct
+@@ -422,9 +422,14 @@ batadv_mcast_mla_softif_get_ipv6(struct
  		return 0;
  	}
  
@@ -22,7 +22,7 @@ Signed-off-by: Sven Eckelmann <sven@narfation.org>
  		if (IPV6_ADDR_MC_SCOPE(&pmc6->mca_addr) <
  		    IPV6_ADDR_SCOPE_LINKLOCAL)
  			continue;
-@@ -454,6 +459,9 @@ batadv_mcast_mla_softif_get_ipv6(struct
+@@ -453,6 +458,9 @@ batadv_mcast_mla_softif_get_ipv6(struct
  		hlist_add_head(&new->list, mcast_list);
  		ret++;
  	}

--- a/batman-adv/patches/0004-Revert-batman-adv-Switch-to-kstrtox.h-for-kstrtou64.patch
+++ b/batman-adv/patches/0004-Revert-batman-adv-Switch-to-kstrtox.h-for-kstrtou64.patch
@@ -1,0 +1,19 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Tue, 14 Sep 2021 21:02:10 +0200
+Subject: Revert "batman-adv: Switch to kstrtox.h for kstrtou64"
+
+This header is only available after Linux 5.14
+
+This reverts commit c9a69cb4048ebef3a4d91835669011a26d9b7dab.
+
+--- a/net/batman-adv/gateway_common.c
++++ b/net/batman-adv/gateway_common.c
+@@ -10,7 +10,7 @@
+ #include <linux/atomic.h>
+ #include <linux/byteorder/generic.h>
+ #include <linux/errno.h>
+-#include <linux/kstrtox.h>
++#include <linux/kernel.h>
+ #include <linux/limits.h>
+ #include <linux/math64.h>
+ #include <linux/netdevice.h>

--- a/batman-adv/patches/0005-Revert-batman-adv-use-Linux-s-stdarg.h.patch
+++ b/batman-adv/patches/0005-Revert-batman-adv-use-Linux-s-stdarg.h.patch
@@ -1,0 +1,19 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Tue, 14 Sep 2021 21:07:34 +0200
+Subject: Revert "batman-adv: use Linux's stdarg.h"
+
+This header is only available since Linux 5.15
+
+This reverts commit 36d059797a14f0e373fdc3c79df7b467435925ad.
+
+--- a/net/batman-adv/log.c
++++ b/net/batman-adv/log.c
+@@ -7,7 +7,7 @@
+ #include "log.h"
+ #include "main.h"
+ 
+-#include <linux/stdarg.h>
++#include <stdarg.h>
+ 
+ #include "trace.h"
+ 

--- a/batman-adv/src/compat-hacks.h
+++ b/batman-adv/src/compat-hacks.h
@@ -92,6 +92,28 @@ br_multicast_has_router_adjacent(struct net_device *dev, int proto)
 
 #endif /* LINUX_VERSION_IS_LESS(5, 14, 0) */
 
+#if LINUX_VERSION_IS_LESS(5, 15, 0)
+
+static inline void batadv_dev_put(struct net_device *dev)
+{
+	if (!dev)
+		return;
+
+	dev_put(dev);
+}
+#define dev_put batadv_dev_put
+
+static inline void batadv_dev_hold(struct net_device *dev)
+{
+	if (!dev)
+		return;
+
+	dev_hold(dev);
+}
+#define dev_hold batadv_dev_hold
+
+#endif /* LINUX_VERSION_IS_LESS(5, 15, 0) */
+
 /* <DECLARE_EWMA> */
 
 #include <linux/version.h>


### PR DESCRIPTION
Maintainer: @simonwunderlich 
Compile tested: x86
Run tested: x86, qemu-system-x86_64

Description:

batman-adv
==========

* support latest kernels (4.4 - 5.15)
* coding style cleanups and refactoring
* reduced memory copy overhead when sending broadcasts

batctl
====

* (no changes)

alfred
======

* (no changes)