### PR TITLE
opennds: Release v9.4.0

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=9.3.0
+PKG_VERSION:=9.4.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=opennds-$(PKG_VERSION).tar.gz
-PKG_HASH:=719e128c4f08af4ad1924f8f1b1b63262c16e10f63b390a4c5c394cfc232aa20
+PKG_HASH:=fc2fa2e810ade5b281885f6ca3c2bb7ceb8d87176f2072e8ef9d75aa816e21e9
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>
@@ -34,7 +34,8 @@ endef
 define Package/opennds/description
 	openNDS is a Captive Portal solution that offers an instant way to provide restricted access to the Internet.
 	With little or no configuration, a dynamically generated and adaptive splash page sequence is automatically served.
-	Internet access is granted by either a click to continue button, or after credential verification.
+	Both client driven Captive Portal Detection (CPD) and gateway driven Captive Portal Identification (CPI) are supported.
+	Internet access is granted by either a click to continue button, or after credential verification as a result of filling in a login form.
 	The package incorporates the FAS API allowing many flexible customisation options.
 	The creation of sophisticated third party authentication applications is fully supported.
 	Internet hosted https portals can be utilised to inspire maximum user confidence.


### PR DESCRIPTION
Maintainer: Rob White rob@blue-wave.net
Compile tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc
Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, gl-inet b1300, gl-inet mt300n-v2, Snapshot, 21.02.0, 19.07.8

Description:
This version adds new functionality, and fixes some issues
  * Add - Error message in fas-aes-https if shared key is mismatched [bluewave.net]
  * Fix - and refactor error 511 page generation[bluewave.net]
  * Fix - and refactor dnsmasq configuration [bluewave.net]
  * Fix - Typographic error preventing RFC8910 disable [bluewave.net]
  * Add - gateway address and gatewayfqdn to ndsctl json output [bluewave.net]
  * Add - RFC8910 housekeeping on startup and shutdown [bluewave.net]
  * Add - correctly apply dhcp option 114 for generic Linux [bluewave.net]
  * Add - reading of configured ndsctlsocket in ndsctl utility[bluewave.net]
  * Add - use send_error 200 for MHD watchdog [bluewave.net]
  * Add - generation of page_511 html by library script [bluewave.net]
  * Add - extend debuglevel support to library scripts [bluewave.net]
  * Refactor - fas-aes-https to simplify and make customisation of http easier [bluewave.net]
  * Add - library script for error 511 page, allowing customisation [bluewave.net]
  * Add - make authmon report connection error details [bluewave.net]
  * Fix- remove unwanted debug message in ndsctl [bluewave.net]
  * Add - RFC8910 support by default [bluewave.net]
  * Add - display status page when accessing /login when authenticated [bluewave.net]
  * Add - MHD response to RFC8910 requests [bluewave.net]
  * Add - Dnsmasq RFC8910 configuration [bluewave.net]
  * Add - send error 511 in response to unsupported http method [bluewave.net]
  * Add - Check for ca-bundle on OpenWrt, if not installed, add syslog messages and terminate [bluewave.net]
  * Add - Make ndsctl use the configured value for socket path if set and deprecate -s option [bluewave.net]
  * Add - Warning message when Walled Garden port 80 is allowed [bluewave.net]
  * Fix - remove un-needed pthread_kill in termination_handler() [bluewave.net] [T-X]
  * Fix - debug messages from authmon.sh [bluewave.net]
  * Fix - Allow disabling gateway fqdn, facilitating access to router port 80 [bluewave.net]
  * Fix - Segfault in ndsctl when -s option is used incorrectly [bluewave.net] [T-X]
  * Fix - Typo making calculation of ul/dl rates incorrect [bluewave.net]
  * Fix - Allow port 80 to be configured in the Walled Garden [bluewave.net]

Signed-off-by: Rob White <rob@blue-wave.net>
