### PR TITLE
[21.02] naywatch: warn user

### DIFF
--- a/naywatch/Makefile
+++ b/naywatch/Makefile
@@ -23,7 +23,12 @@ define Package/naywatch
 endef
 
 define Package/naywatch/description
-Reboots or triggers watchdog if no link local neighbor is available.
+Reboots or triggers watchdog if no link-local neighbor is available.
+
+Important:
+Be careful when you do a sysupgrade. Stop naywatch first, and make
+sure procd took control again of the watchdog.
+You can do this using 'ubus call system watchdog'.  Status should be "running".
 endef
 
 define Package/naywatch/conffiles

--- a/naywatch/files/naywatch.config
+++ b/naywatch/files/naywatch.config
@@ -1,7 +1,7 @@
 config naywatch general
     option check_interval   '50'
     option watchdog_timeout '60'
-    option use_watchdog     '1'
+    option use_watchdog     '0'
     option save_logs        '1'
     list interface          'lan'
     list interface          'wan'


### PR DESCRIPTION
Naywatch in combination with the watchdog can be tricky and dangerous
when doing a sysupgrade. Add a warning to always stop naywatch first and
check if procd took control over the watchdog again.

Also change use_watchdog to '0'.
