### PR TITLE
batman-adv: update packages to version 2021.4

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alfred
-PKG_VERSION:=2021.3
+PKG_VERSION:=2021.4
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=be6229edf2a3e9cf69122e5283d113e9405f1455e8fd4ebd55294e9bf9157b5a
+PKG_HASH:=4c79b6c45de4bcc8cbfe64cba9a0f8b4ef304ca84c194622f2bfa41e01e2cb95
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
 PKG_LICENSE:=GPL-2.0-only MIT

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
-PKG_VERSION:=2021.3
+PKG_VERSION:=2021.4
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=f22f4befc28f8a4609f1f8403b4c40ea01b83e4f9448453e2bbae3db7b47fc20
+PKG_HASH:=b6d96e908e3295a1413e8ec4f0f9851f85c67c752ac45bebbbe58aad40fad8e7
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
-PKG_VERSION:=2021.3
+PKG_VERSION:=2021.4
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=b24deec9baee786ca91085e32f7e09d4cc94f965ae71c9560895f82ec1cc906b
+PKG_HASH:=cff7a2f160045fd0dbf1f1cd7e35e93bf489e81cb8b9501b3756daa391f3eb1b
 PKG_EXTMOD_SUBDIRS:=net/batman-adv
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/src/compat-hacks.h
+++ b/batman-adv/src/compat-hacks.h
@@ -112,6 +112,13 @@ static inline void batadv_dev_hold(struct net_device *dev)
 }
 #define dev_hold batadv_dev_hold
 
+static inline void batadv_eth_hw_addr_set(struct net_device *dev,
+					  const u8 *addr)
+{
+	ether_addr_copy(dev->dev_addr, addr);
+}
+#define eth_hw_addr_set batadv_eth_hw_addr_set
+
 #endif /* LINUX_VERSION_IS_LESS(5, 15, 0) */
 
 /* <DECLARE_EWMA> */


### PR DESCRIPTION
Maintainer: @simonwunderlich 
Compile tested: x86
Run tested: x86, qemu-system-x86_64

Description:

batman-adv
==========

* support latest kernels (4.4 - 5.16)
* coding style cleanups and refactoring
* bugs squashed:
  - fix error handling during interface initialization

batctl
====

* (no changes)

alfred
======

* (no changes)