### PR TITLE
Enable vtysh for all daemons.

### DIFF
--- a/quagga/Makefile
+++ b/quagga/Makefile
@@ -171,6 +171,7 @@ CONFIGURE_ARGS+= \
 	--enable-user=network \
 	--enable-group=network \
 	--enable-multipath=8 \
+	--enable-vtysh \
 	--disable-ospfclient \
 	--disable-capabilities \
 	--disable-doc \


### PR DESCRIPTION
Running watchquagga does not make any sense without vtysh interface accessible via unix sockets created in /var/run/quagga. Without these sockets watchquagga is unable to check status of daemons, so it assumes they are dead and restarts them periodically, even if they are working fine. Only one configure option is needed to make it work properly.
