### PR TITLE
batman-adv: Prevent use from libc headers to not build with BIG_ENDIAN

### DIFF
--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -61,6 +61,7 @@ PKG_EXTRA_CFLAGS:= \
 	$(patsubst CONFIG_%, -DCONFIG_%=1, $(patsubst %=y,%,$(filter %=y,$(PKG_EXTRA_KCONFIG)))) \
 
 NOSTDINC_FLAGS = \
+	$(KERNEL_NOSTDINC_FLAGS) \
 	-I$(PKG_BUILD_DIR)/net/batman-adv \
 	-I$(STAGING_DIR)/usr/include/mac80211-backport \
 	-I$(STAGING_DIR)/usr/include/mac80211-backport/uapi \


### PR DESCRIPTION
Commit 97d35a552ec5b6ddf7923dd2f9a8eb973526acea of musl introduced the
macros __LITTLE_ENDIAN and __BIG_ENDIAN in alltypes.h. These are pulled
into the compilation of batman-adv. This has the side effect that the
function is_multicast_ether_addr of etherdevice.h in Linux kernel is
compiled as the big endian version and so fails to work properly on
little endian devices.

This commit fixes that by preventing to pull in std includes and by
providing the minimal stdarg.h that Linux now provides with recent
versions. The included header file comes from Linux upstream commit
c0891ac15f0428ffa81b2e818d416bdf3cb74ab6.

Signed-off-by: Hendrik Borghorst <hendrikborghorst@gmail.com>

Maintainer: @ecsv , @simonwunderlich 
Compile tested: ramips/mt7621/wac124
Run tested: OpenWRT master @ fb6c34d355e19152550a8347cde13e1c359f1aca 

Batman finds neighbor nodes properly again.

Description:
