### PR TITLE
openwrt-21.02: batman-adv: Prevent use from libc headers to not build with BIG_ENDIAN

### DIFF
--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -61,6 +61,7 @@ PKG_EXTRA_CFLAGS:= \
 	$(patsubst CONFIG_%, -DCONFIG_%=1, $(patsubst %=y,%,$(filter %=y,$(PKG_EXTRA_KCONFIG)))) \
 
 NOSTDINC_FLAGS = \
+	$(KERNEL_NOSTDINC_FLAGS) \
 	-I$(PKG_BUILD_DIR)/net/batman-adv \
 	-I$(STAGING_DIR)/usr/include/mac80211-backport \
 	-I$(STAGING_DIR)/usr/include/mac80211-backport/uapi \


### PR DESCRIPTION
Maintainer: @simonwunderlich 
Compile tested: OpenWrt 21.02, x86-64
Run tested: -

Description:

Commit 97d35a552ec5b6ddf7923dd2f9a8eb973526acea of musl introduced the macros __LITTLE_ENDIAN and __BIG_ENDIAN in alltypes.h. These are pulled into the compilation of batman-adv. This has the side effect that the
function is_multicast_ether_addr of etherdevice.h in Linux kernel is compiled as the big endian version and so fails to work properly onlittle endian devices.

This commits prevents pulling in header files of musl libc similar to OpenWRT commit 9ac47ee46918c45b91f4e4d1fa76b1e26b9d57fe
