### PR TITLE
batman-adv: Drop duplicated dev_{hold,put} compat helpers

### DIFF
--- a/batman-adv/src/compat-hacks.h
+++ b/batman-adv/src/compat-hacks.h
@@ -94,24 +94,6 @@ br_multicast_has_router_adjacent(struct net_device *dev, int proto)
 
 #if LINUX_VERSION_IS_LESS(5, 15, 0)
 
-static inline void batadv_dev_put(struct net_device *dev)
-{
-	if (!dev)
-		return;
-
-	dev_put(dev);
-}
-#define dev_put batadv_dev_put
-
-static inline void batadv_dev_hold(struct net_device *dev)
-{
-	if (!dev)
-		return;
-
-	dev_hold(dev);
-}
-#define dev_hold batadv_dev_hold
-
 static inline void batadv_eth_hw_addr_set(struct net_device *dev,
 					  const u8 *addr)
 {


### PR DESCRIPTION
Maintainer: @simonwunderlich 
Compile tested: x86-64
Run tested: -

Description:

The mac80211 package in OpenWrt master is now already providing helpers for the changed dev_{hold,put} behavior in Linux 5.15. It is no longer necessary to ship them as part of the batman-adv package.