### PR TITLE
pimbd: add config load on start

### DIFF
--- a/pimbd/Makefile
+++ b/pimbd/Makefile
@@ -45,6 +45,8 @@ define Package/pimbd/install
 	$(INSTALL_BIN) ./files/pimbd.init $(1)/etc/init.d/pimbd
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) files/firewall-uci.sh $(1)/etc/uci-defaults/99_pimbd_firewall
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/pimb.config $(1)/etc/config/pimb
 endef
 
 $(eval $(call BuildPackage,pimbd))

--- a/pimbd/files/pimb.config
+++ b/pimbd/files/pimb.config
@@ -1,0 +1,34 @@
+# The interface section allows to enable pimb on an interface.
+# Several options can be enabled for the interface.
+# All options are disabled by default.
+#
+#config interface '<interface section name>'
+# option pim '<on | off>'     - enable or disable pim
+# option ssbidir '<on | off>' - enable or disable ssbidir
+# option mld '<on | off>'     - enable or disable mld
+# option igmp '<on | off>'    - enable or disable igmp
+# option dev '<device name>'  - set the device name
+
+# The rpa section allows to configure a rendevous point.
+# The interface and the networks must be configured for every rendevous.
+#
+#config rpa '<rendevous point name>'
+# option address '<ip address>'       - rendevous point address
+# list prefix '<net>/<prefix length>' - prefix for the rpa
+
+
+
+# Uncomment the following following section to enable pimb on the interface eth1.
+#config interface 'ETH1'
+#	option pim 'on'
+#	option ssbidir 'on'
+#	option mld 'on'
+#	option igmp 'on'
+#	option dev 'eth1'
+
+
+# Uncomment the following section to configure a rendevous point.
+#config rpa '172_16_0_1'
+#	option address '172.16.0.1'
+#	list prefix '224.0.0.0/4'
+

--- a/pimbd/files/pimbd.init
+++ b/pimbd/files/pimbd.init
@@ -4,18 +4,147 @@ START=90
 STOP=10
 USE_PROCD=1
 
+TYPE=''
+
+DEV=''
+PIM='off'
+SSBIDIR='off'
+MLD='off'
+IGMP='off'
+
+RPAADDRESS=''
+RPALIST=''
+
+reset_link_values() {
+    PIM='off'
+    SSBIDIR='off'
+    MLD='off'
+    IGMP='off'
+}
+
+apply_link() {
+    if test ! -z "$DEV"; then
+        echo "Setting pimbc link set $DEV pim $PIM ssbidir $SSBIDIR mld $MLD igmp $IGMP"
+        echo "link set $DEV pim $PIM ssbidir $SSBIDIR mld $MLD igmp $IGMP" >> /tmp/pimbd.conf
+    fi
+    reset_link_values
+}
+
+apply_rpa() {
+    if test -z "$RPAADDRESS"; then
+        echo "No RPA address is set!"
+        return
+    fi
+    for i in $RPALIST; do
+        echo "adding pimbc rpa add $RPAADDRESS $i"
+        echo "rpa add $RPAADDRESS $i" >> /tmp/pimbd.conf
+    done
+    RPAADDRESS=''
+    RPALIST=''
+}
+
+store_interface_option() {
+    local name="$1"
+    local value="$2"
+    case $name in
+    dev)
+        DEV=$value
+        ;;
+    pim)
+        PIM=$value
+        ;;
+    ssbidir)
+        SSBIDIR=$value
+        ;;
+    mld)
+        MLD=$value
+        ;;
+    igmp)
+        IGMP=$value
+        ;;
+    esac
+}
+
+store_rpa_option() {
+    local name="$1"
+    local value="$2"
+    echo "store_rpa_option $name $value"
+    case $name in
+    address)
+        RPAADDRESS="$value"
+        ;;
+    esac
+}
+
+store_rpa_list() {
+    local name="$1"
+    local value="$2"
+    echo "store rpa_list $name $value"
+    case $name in
+    prefix)
+        RPALIST="${RPALIST} $value"
+        ;;
+    esac
+}
+
 start_service() {
     . /lib/functions.sh
     . /lib/functions/network.sh
+
+    rm -f /tmp/pimbd.conf
+
+    config_cb() {
+        local name="$1"
+        local value="$2"
+        # commands to be run for every option
+        echo "config_cb $name $value"
+        case $TYPE in
+        interface)
+            apply_link
+            ;;
+        rpa)
+            apply_rpa
+            ;;
+        esac
+        TYPE=$name
+        DEV=$value
+    }
+
+    option_cb() {
+        local name="$1"
+        local value="$2"
+        # commands to be run for every option
+        echo "option_cb $name $value"
+        case $TYPE in
+        interface)
+            store_interface_option "$name" "$value"
+            ;;
+        rpa)
+            store_rpa_option "$name" "$value"
+            ;;
+        esac
+    }
+
+    list_cb() {
+        local name="$1"
+        local value="$2"
+        # commands to be run for every list item
+        echo "list_cb $name $value"
+
+        case $TYPE in
+        rpa)
+            store_rpa_list "$name" "$value"
+            ;;
+        esac
+    }
     config_load pimb
 
     procd_open_instance
     procd_set_param command /usr/sbin/pimbd
     procd_append_param command -S
     procd_append_param command -L 6
+    procd_append_param command -c /tmp/pimbd.conf
 
     procd_set_param respawn
     procd_close_instance
 }
-
-


### PR DESCRIPTION
Generate config file from uci and set as start config on start of pimbd.

Signed-off-by: Christian Strebe <uipo@freenet.de>

Maintainer: Pierre Pfister
Compile tested: x86_64, NF533, 21.02.1
Run tested: x86_64, NF533, 21.02.0-rc3

Description:
Enable the pimbd to load the configuration on start.