### PR TITLE
ohybridproxy: revert to default log level

### DIFF
--- a/ohybridproxy/Makefile
+++ b/ohybridproxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=ohybridproxy
 PKG_SOURCE_VERSION:=0dfef1eb5f067250a5f24a899536879ea4fdc4c5
 PKG_SOURCE_DATE:=2020-05-22
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/sbyx/ohybridproxy.git
@@ -23,9 +23,6 @@ PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
-
-# Spammy debug builds for now
-CMAKE_OPTIONS += -DL_LEVEL=7
 
 define Package/ohybridproxy
   SECTION:=net


### PR DESCRIPTION
Change log level from debug to info to avoid filling up syslog with query-level logging.

Signed-off-by: Maarten Aertsen <spam-github@rtsn.nl>
(cherry picked from commit 4f235865e7d8c37b4ea7d8ee55b4e603a11e06b7)

PR #741 got this change landed in master. 

Maintainer: @fingon / @PolynomialDivision 