### PR TITLE
mrd6: fix compilation under macOS

### DIFF
--- a/mrd6/Makefile
+++ b/mrd6/Makefile
@@ -52,7 +52,8 @@ MRD6_MAKEFLAGS:= \
 	LDFLAGS="$(TARGET_LDFLAGS) -ldl -lm" \
 	MODULE_CXX="\$$$$(CC) -shared \$$$$(CXXFLAGS) \$$$$(LDFLAGS)" \
 	DESTDIR="$(PKG_INSTALL_DIR)" \
-	PREFIX="/usr"
+	PREFIX="/usr" \
+	KERNEL=Linux
 
 define Build/Compile
 	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/src $(MRD6_MAKEFLAGS) all


### PR DESCRIPTION
uname variable needs to be overriden.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @sbyx 
Compile tested: macOS

ping @PolynomialDivision 