### PR TITLE
opennds: Release v9.5.1

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=9.4.0
+PKG_VERSION:=9.5.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=opennds-$(PKG_VERSION).tar.gz
-PKG_HASH:=fc2fa2e810ade5b281885f6ca3c2bb7ceb8d87176f2072e8ef9d75aa816e21e9
+PKG_HASH:=650922ec0faa28e0eba8b0f088dd353fa2ff74318db705458b8d62159e40e377
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>
@@ -34,11 +34,11 @@ endef
 define Package/opennds/description
 	openNDS is a Captive Portal solution that offers an instant way to provide restricted access to the Internet.
 	With little or no configuration, a dynamically generated and adaptive splash page sequence is automatically served.
-	Both client driven Captive Portal Detection (CPD) and gateway driven Captive Portal Identification (CPI) are supported.
+	Both client driven Captive Portal Detection (CPD) and gateway driven Captive Portal Identification (CPI - RFC 8910 and RFC 8908) are supported.
 	Internet access is granted by either a click to continue button, or after credential verification as a result of filling in a login form.
 	The package incorporates the FAS API allowing many flexible customisation options.
 	The creation of sophisticated third party authentication applications is fully supported.
-	Internet hosted https portals can be utilised to inspire maximum user confidence.
+	Internet hosted https portals can be implemented with no security errors, to inspire maximum user confidence.
 endef
 
 define Package/opennds/install


### PR DESCRIPTION
Maintainer: Rob White rob@blue-wave.net
Compile tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc
Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, gl-inet b1300, gl-inet mt300n-v2, Snapshot, 21.02.1, 19.07.8

Description:
This version adds new functionality, and fixes some issues
  * Fix - ThemeSpec file downloads when mwan3 is running [bluewavenet]
  * Fix - Preemptive auth failure after previous deauth [minhng99] [bluewavenet]

From v9.5.0
  * Add - use average packet size instead of MTU when implementing rate limiting [bluewavenet]
  * Fix - typo in iptables command and remove a redundant command [bluewavenet]
  * Add - startdaemon() and stopdaemon() utility functions [bluewavenet]
  * Add - combined interface/ipaddress external gateway status monitoring [bluewavenet]
  * Fix - potential online/offline detection problem when mwan3 is running [bluewavenet]
  * Add - get_debug_level and syslog library calls [bluewavenet]
  * Fix - correctly reset upload and download rate rules [bluewavenet]
  * Add - extend upstream gateway checking for use with mwan3 loadbalance/failover [bluewavenet]
  * Fix - Potential NULL pointer segfault in http_microhttpd on calling authenticated() [bluewavenet]
  * Fix - Potential NULL pointer segfault in http_microhttpd on calling preauthenticated() [dddaniel]
  * Add - Calculate Bucket size based on achieved burst rate [bluewavenet]
  * Fix - prevent parameter parsing if clientip not known [bluewavenet]
  * Add - disable rate quotas by setting bucket ratio to zero [bluewavenet]
  * Fix - suppress some debug messages [bluewavenet]
  * Add - more libraries documentation [bluewavenet]
  * Add - library calls startdaemon and stopdaemon [bluewavenet]
  * Fix - Increase buffer length for longer interface names [koivunen]
  * Add - Update README.md [bluewavenet]
  * Add - bucket ratio option to config file [bluewavenet]
  * Add - upload and download bucket ratio config values [bluewavenet]
  * Fix - flag initial debuglevel to externals [bluewavenet]
  * Add - limit-burst tuning to rate quotas [bluewavenet]
  * Fix - add trailing space to defaultip [bluewavenet]
  * Add - record pre-emptive authentication in local log [bluewavenet]
  * Add - Write to local log function to libopennds [bluewavenet]
  * Add - set client_type and custom string for Pre-emptive authentication [bluewavenet]
  * Fix - Remove trailing newline from library call response [bluewavenet]
  * Fix - attempt to remove cid file only if client->cid is set [bluewavenet]
  * Add - a skip option for custom downloads to speed up serving page from themespec [bluewavenet]
  * Add - put client_type into query string when type is cpd canary [bluewavenet]
  * Add - set refresh=0 before loading images [bluewavenet]
  * Fix - Truncated return status [bluewavenet]
  * Add - Acknowlegement from call to dnsconfig [bluewavenet]
  * Fix - potential buffer overflow in debug output [bluewavenet]
  * Add - processing of custom data and client type [bluewavenet]
  * Add - Client Type for RFC8908 and RFC8910 clients [bluewavenet]
  * Add - rfc8908 replies for external FAS and refactor memory management for MHD calls [bluewavenet]
  * Add - send error 403 if client is not on openNDS subnet [bluewavenet]
  * Fix - remove uneccessary safe_asprint in auth.c [bluewavenet]
  * Fix - Initialise buffer to prevent receiving spurious characters [bluewavenet]
  * Add - encoded custom data support to ndsctl json, themespec and binauth [bluewavenet]
  * Add - advert_1.htm to thankyou page of theme_click-to-continue-custom-placeholders.sh [bluewavenet]
  * Add - library call get_interface_by_ip [bluewavenet]
  * Add - function encode_custom() for encoding custom data to be sent to openNDS [bluewavenet]
  * Fix - error 511, make all html refrences absolute to enforce link to MHD [bluewavenet]
  * Add - check status_path exists and is executeable [bluewavenet]
  * Fix - regression causing error 511 to be served from default script [bluewavenet]
  * Add - venue-info-url and can-extend-session json keys [bluewavenet]
  * Add - RFC 8908 initial experimental support [bluewavenet]
  * Add - debug message when resetting client [bluewavenet]
  * Fix - Ensure the ndscids directory exists before trying to write to it. [bluewavenet]
  * Fix - use eval in do_ndsctl to allow quoting of arguments [bluewavenet]
  * Fix - ensure client hid and client cid file is reset correctly [bluewavenet]
  * Fix - Titles of example ThemeSpec Files [bluewavenet]
  * Fix - Ensure ThemeSpec Files are executable [bluewavenet]
  * Remove - deprecated Allowed and Blocked entries in ndsctl status output [bluewavenet]
  * Add - Deprecate option macmechanism, allowedmaclist and blockedmaclist [bluewavenet]

Signed-off-by: Rob White <rob@blue-wave.net>
