### PR TITLE
olsrd: fix meshing via wireguard tunnels

### DIFF
--- a/olsrd/files/olsrd.sh
+++ b/olsrd/files/olsrd.sh
@@ -624,6 +624,10 @@ olsrd_write_interface() {
 					ifnames="$ifnames \"$IFNAME\""
 					ifsglobal="$ifsglobal $IFNAME"
 				fi
+			elif [[ "$(ip -details link show dev $interface)" == *"wireguard"* ]]; then
+				# wireguard interface
+				ifnames="$ifnames \"$interface\""
+				ifsglobal="$ifsglobal $interface"
 			else
 				log "$funcname() Warning: Interface '$interface' not found, skipped"
 			fi


### PR DESCRIPTION
The procd script was not adding the wireguard interfaces. Add corner case in the init script to allow meshing via wireguard.