### PR TITLE
olsrd: only regenerate the config on reload

### DIFF
--- a/olsrd/files/olsrd4.init
+++ b/olsrd/files/olsrd4.init
@@ -36,6 +36,12 @@ boot()
 	rc_procd start_service
 }
 
+reload_service()
+{
+	olsrd_generate_config $OLSRD
+	killall -s SIGHUP $OLSRD
+}
+
 start_service() {
 	olsrd_generate_config $OLSRD
 

--- a/olsrd/files/olsrd6.init
+++ b/olsrd/files/olsrd6.init
@@ -28,6 +28,12 @@ wait_for_wireless()
 	done
 }
 
+reload_service()
+{
+	olsrd_generate_config $OLSRD
+	killall -s SIGHUP $OLSRD
+}
+
 boot()
 {
 	config_load network


### PR DESCRIPTION
A reload kills the olsrd daemon. However, the option AllowNoInt allows
to dynamically add and remove interfaces without a restart. Stop
restarting the complete daemon. A restart destroys all the metrics and
will harm the smoothness of the mesh network.