### PR TITLE
[21.02] CI: fix runtime testing for non master branch

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -116,7 +116,7 @@ jobs:
         run: |
           docker build -t test-container --build-arg ARCH .github/workflows/
         env:
-          ARCH: ${{ matrix.arch }}
+          ARCH: ${{ matrix.arch }}-${{ env.BRANCH }}
 
       - name: Test via Docker container
         if: ${{ matrix.runtime_test }}


### PR DESCRIPTION
The runtime testing always ran on master branch aka snapshots since the
branch wasn't passed over to the container execution!

Signed-off-by: Paul Spooren <mail@aparcar.org>
(cherry picked from commit 817240b07c7158c72de427051eb9bae1c39b3abe)