### PR TITLE
babeld: add add_interface function

### DIFF
--- a/babeld/src/ubus.c
+++ b/babeld/src/ubus.c
@@ -54,6 +54,42 @@ struct neighbour_list_entry {
   struct neighbour *neighbour;
 };
 
+// Definition of interface function enums (to be used with ubox's blobmsg
+// helpers).
+enum { INTERFACE_IFNAME, __INTERFACE_MAX };
+
+// Definition of interface parsing (to be used with ubox's blobmsg helpers).
+static const struct blobmsg_policy interface_policy[__INTERFACE_MAX] = {
+    [INTERFACE_IFNAME] = {"ifname", BLOBMSG_TYPE_STRING},
+};
+
+// Adds an inteface (ubus equivalent to "interface"-function).
+static int babeld_ubus_add_interface(struct ubus_context *ctx_local,
+                                     struct ubus_object *obj,
+                                     struct ubus_request_data *req,
+                                     const char *method,
+                                     struct blob_attr *msg) {
+  struct blob_attr *tb[__INTERFACE_MAX];
+  struct blob_buf b = {0};
+  struct interface *ifp = NULL;
+  int ret;
+  char *ifname;
+
+  blobmsg_parse(interface_policy, __INTERFACE_MAX, tb, blob_data(msg),
+                blob_len(msg));
+
+  if (!tb[INTERFACE_IFNAME])
+    return UBUS_STATUS_INVALID_ARGUMENT;
+
+  ifname = blobmsg_get_string(tb[INTERFACE_IFNAME]);
+
+  ifp = add_interface(ifname, NULL);
+  if (ifp == NULL)
+    return UBUS_STATUS_UNKNOWN_ERROR;
+
+  return UBUS_STATUS_OK;
+}
+
 // Sends a babel info message on ubus socket.
 static int babeld_ubus_babeld_info(struct ubus_context *ctx_local,
                                    struct ubus_object *obj,
@@ -328,6 +364,7 @@ static int babeld_ubus_get_neighbours(struct ubus_context *ctx_local,
 
 // List of functions we expose via the ubus bus.
 static const struct ubus_method babeld_methods[] = {
+    UBUS_METHOD("add_interface", babeld_ubus_add_interface, interface_policy),
     UBUS_METHOD_NOARG("get_info", babeld_ubus_babeld_info),
     UBUS_METHOD_NOARG("get_xroutes", babeld_ubus_get_xroutes),
     UBUS_METHOD_NOARG("get_routes", babeld_ubus_get_routes),

--- a/babeld/src/ubus.h
+++ b/babeld/src/ubus.h
@@ -2,6 +2,7 @@
     IPC integration of babeld with OpenWrt.
 
     The ubus interface offers following functions:
+    - add_interface '{"ifname":"eth0"}'
     - get_info
     - get_neighbours
     - get_xroutes


### PR DESCRIPTION
An interface can be added dynmiacally to babeld by starting babeld with
the local management interface (-G) and saying:

    interface eth0

Add the ubus equivalent of this function:

    ubus call babeld add_interface '{"ifname":"eth0"}'

