### PR TITLE
babeld: remove unused return variable

### DIFF
--- a/babeld/src/ubus.c
+++ b/babeld/src/ubus.c
@@ -72,7 +72,6 @@ static int babeld_ubus_add_interface(struct ubus_context *ctx_local,
   struct blob_attr *tb[__INTERFACE_MAX];
   struct blob_buf b = {0};
   struct interface *ifp = NULL;
-  int ret;
   char *ifname;
 
   blobmsg_parse(interface_policy, __INTERFACE_MAX, tb, blob_data(msg),


### PR DESCRIPTION
There is an unused variable in the function. Remove it.

Fixes: 385200443554 ("babeld: add add_interface function").
