### PR TITLE
olsrd: don't start service when ignored

### DIFF
--- a/olsrd/files/olsrd.config
+++ b/olsrd/files/olsrd.config
@@ -1,6 +1,7 @@
-config olsrd
+config olsrd olsrd
 	# uncomment the following line to use a custom config file instead:
 	#option config_file '/etc/olsrd.conf'
+	option ignore 0
 
 config LoadPlugin
 	option library 'olsrd_arprefresh.so.0.1'

--- a/olsrd/files/olsrd4.init
+++ b/olsrd/files/olsrd4.init
@@ -39,17 +39,20 @@ boot()
 start_service() {
 	olsrd_generate_config $OLSRD
 
-	procd_open_instance
-
 	config_load olsrd
 	local _respawn_threshold
 	local _respawn_timeout
 	local _respawn_retry
+	local _ignore
 
 	config_get _respawn_threshold procd respawn_threshold 3600
 	config_get _respawn_timeout procd respawn_timeout 15
 	config_get _respawn_retry procd respawn_retry 0
+	config_get_bool _ignore olsrd ignore 0
 
+	[ $_ignore -ne 0 ] && return
+
+	procd_open_instance
 	procd_set_param command "$BIN"
 	procd_append_param command -f ${CONF}
 	procd_append_param command -nofork

--- a/olsrd/files/olsrd6.config
+++ b/olsrd/files/olsrd6.config
@@ -1,6 +1,7 @@
-config olsrd
+config olsrd olsrd
 	# uncomment the following line to use a custom config file instead:
 	#option config_file '/etc/olsrd6.conf'
+	option ignore 0
 
 config LoadPlugin
 	option library 'olsrd_txtinfo.so.1.1'

--- a/olsrd/files/olsrd6.init
+++ b/olsrd/files/olsrd6.init
@@ -39,17 +39,20 @@ boot()
 start_service() {
 	olsrd_generate_config $OLSRD
 
-	procd_open_instance
-
 	config_load olsrd6
 	local _respawn_threshold
 	local _respawn_timeout
 	local _respawn_retry
+	local _ignore
 
 	config_get _respawn_threshold procd _respawn_threshold 3600
 	config_get _respawn_timeout procd respawn_timeout 15
 	config_get _respawn_retry procd respawn_retry 0
+	config_get_bool _ignore olsrd ignore 0
 
+	[ $_ignore -ne 0 ] && return
+
+	procd_open_instance
 	procd_set_param command "$BIN"
 	procd_append_param command -f ${CONF}
 	procd_append_param command -nofork


### PR DESCRIPTION
When olsrd was disabled by uci (olsrd.olsrd.ignore=true),
the service got started anyway.
This results in olsrd spamming the syslog when getting started by
procd without a valid configuration:
--
daemon.err olsrd[8223]: olsrd exit: main: Bad configuration
--

This commit only starts the olsrd service when not set to ignore.

Signed-off-by: Daniel Danzberger <daniel@dd-wrt.com>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
