### PR TITLE
opennds: Release v9.6.0 (for 21.02)

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=9.5.1
+PKG_VERSION:=9.6.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=opennds-$(PKG_VERSION).tar.gz
-PKG_HASH:=650922ec0faa28e0eba8b0f088dd353fa2ff74318db705458b8d62159e40e377
+PKG_HASH:=90613e636c668a16eb9d6abfe19715f87cea7000383a53ad6719dec80ff966db
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>
@@ -39,6 +39,7 @@ define Package/opennds/description
 	The package incorporates the FAS API allowing many flexible customisation options.
 	The creation of sophisticated third party authentication applications is fully supported.
 	Internet hosted https portals can be implemented with no security errors, to inspire maximum user confidence.
+	This version requires iptables (legacy).
 endef
 
 define Package/opennds/install


### PR DESCRIPTION
Maintainer: Rob White rob@blue-wave.net
Compile tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc
Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, gl-inet b1300, gl-inet mt300n-v2, Snapshot, 21.02.1, 19.07.8

Description:
This version adds new functionality, and fixes some issues
It requires iptables(legacy)
  * Fix - correctly display return buffer in syslog [bluewavenet]
  * Add - use heap allocation for library call return buffer [bluewavenet]
  * Fix - OpenWrt, fhook request for fw3 [bluewavenet]
  * Add - spider remote urls before downloading [bluewavenet]
  * Add - OpenWrt, revert uncommitted uci updates at startup and shutdown [bluewavenet]
  * Fix - remove unneccesary flash writes and fix hosts updates [doctor-ox] [bluewavenet]
  * Add - Updated splash images [bluewavenet]
  * Add - OpenWrt makefile for nft or ipt dependencies [bluewavenet]
  * Fix - grep by word to prevent any ambiguity [doctor-ox] [bluewavenet]
  * Fix - ensure rate limiting is disabled if rate thresholds are set to zero [bluewavenet]
  * Add - querystring support for client status page [bluewavenet]
  * Add - Advanced/standard status page checkbox [bluewavenet]
  * Add - set default session timeout to 24 hours [bluewavenet]
  * Fix - potential buffer overflow [bluewavenet]
  * Fix - Restrict max packet limit to iptables maximum [bluewavenet]
  * Fix - descriptive labels on ndsctl status output [bluewavenet]
  * Add - update of README.md [bluewavenet]
  * Fix - Added required variable to FAS return string example documentation [dorkone]
  * Add - Default checkinterval set to 15 seconds [bluewavenet]
  * Fix - incoming and outgoing counters when unlimited bursting is enabled [bluewavenet]
  * Add - maximum bucket size configuration [bluewavenet]
  * Add - calculate moving average packet size for rate limiting [bluewavenet]
  * Add - some operational default values [bluewavenet]
  * Add - initial rate limits when unrestricted bursting is disabled [bluewavenet]
  * Add - Require clients to be in the dhcp database [bluewavenet]
  * Add - dhcpcheck library call [bluewavenet]
  * Fix - Remove trailing whitespace when getting clientaddress if client not active [bluewavenet]
  * Fix - Segfault when FAS fails to Return customstring [dorkone] [bluewavenet]
  * Add - Enable/Disable unrestricted bursting [bluewavenet]
  * Add - gatewayurl to querystring and use in place of originurl in FAS [bluewavenet]
  * Fix - more accurate debug message [bluewavenet]
  * Fix - Show packet rate correctly as packets per minute [bluewavenet]
  * Add - Report Packet Rate and Bucket Size in ndsctl status and json and status client page [bluewavenet]
  * Add - rate limit refresh to client limit rules [bluewavenet]
  * Fix - code readability [bluewavenet]
  * Fix - Documentation for data sent to Authmon Daemon [bluewavenet]
  * Add - Show unrestricted burst intervals in ndsctl status [bluewavenet]
  * Add - Set default bucket ratios to 10 [bluewavenet]

Signed-off-by: Rob White <rob@blue-wave.net>
