### PR TITLE
vis: update, refactor Makefile and refresh patch due to fuzz

### DIFF
--- a/vis/Makefile
+++ b/vis/Makefile
@@ -8,19 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vis
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_PROTO:=git
+PKG_SOURCE_DATE:=2013-04-07
+PKG_SOURCE_VERSION:=7710cce42e8d63ea114056a4a140835d4a452933
 PKG_SOURCE_URL:=https://git.open-mesh.org/vis.git
-PKG_REV:=e141311c6a4fc824efbad536c137ed279905d825
-PKG_VERSION:=1440
-PKG_RELEASE:=2
-PKG_LICENSE:=GPL-2.0
+PKG_MIRROR_HASH:=0ed79822a694f220ea44fc81d91ccdacae6ab8ef599810ecfd39acd34d68ae53
 
-PKG_SOURCE_VERSION:=$(PKG_REV)
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE:=$(PKG_SOURCE_SUBDIR).tar.gz
-PKG_MIRROR_HASH:=fd4b337a56993eec9a03ad8e7918bccc7691aa8b2e5ab6dd7863350f07503285
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
+PKG_MAINTAINER:=Corinna "Elektra" Aichele <onelektra@gmx.net>
+PKG_LICENSE:=GPL-2.0-only
 
 PKG_BUILD_PARALLEL:=1
 
@@ -33,7 +30,6 @@ define Package/vis
   DEPENDS:=+libpthread
   TITLE:=visualization server for B.A.T.M.A.N. layer 3
   URL:=https://www.open-mesh.org/
-  MAINTAINER:=Corinna "Elektra" Aichele <onelektra@gmx.net>
 endef
 
 define Package/vis/description

--- a/vis/patches/0001-Allow-one-to-disable-forking-to-background-in-debug_.patch
+++ b/vis/patches/0001-Allow-one-to-disable-forking-to-background-in-debug_.patch
@@ -16,15 +16,15 @@ Subject: Allow one to disable forking to background in debug_mode 0
  
  formats selected_formats = dot_draw;
  
-@@ -716,6 +717,7 @@ void print_usage() {
+@@ -718,6 +719,7 @@ void print_usage() {
  	printf( "Usage: vis <interface(s)> \n" );
  	printf( "\t-j output mesh topology as json on port %d\n", JSON_PORT );
  	printf( "\t-d debug level\n" );
 +	printf( "\t-D run in foreground\n" );
  	printf( "\t-h help\n" );
  	printf( "\t-v Version\n\n" );
- 	printf( "Olsrs3d / Meshs3d is an application to visualize a mesh network.\nIt is a part of s3d, have a look at s3d.berlios.de\n\n" );
-@@ -736,7 +738,7 @@ int main( int argc, char **argv ) {
+ 	printf( "Olsrs3d / Meshs3d is an application to visualize a mesh network.\nIt is a part of s3d, have a look at s3d.sourceforge.net\n\n" );
+@@ -738,7 +740,7 @@ int main( int argc, char **argv ) {
  	fd_set wait_sockets, tmp_wait_sockets;
  
  
@@ -33,7 +33,7 @@ Subject: Allow one to disable forking to background in debug_mode 0
  
  		switch( optchar ) {
  
-@@ -771,6 +773,11 @@ int main( int argc, char **argv ) {
+@@ -773,6 +775,11 @@ int main( int argc, char **argv ) {
  				selected_formats |= json;
  				found_args++;
  				break;
@@ -45,7 +45,7 @@ Subject: Allow one to disable forking to background in debug_mode 0
  
  			default:
  				print_usage();
-@@ -889,7 +896,7 @@ int main( int argc, char **argv ) {
+@@ -891,7 +898,7 @@ int main( int argc, char **argv ) {
  
  
  	/* daemonize */


### PR DESCRIPTION
Maintainer: @elektra42
Compile tested: Turris Omnia, OpenWrt master, mvebu/cortex-a9
Run tested: N/A

Description:

- Update it from https://git.open-mesh.org/vis.git/commit/e141311c6a4fc824efbad536c137ed279905d825 to https://git.open-mesh.org/vis.git/commit/7710cce42e8d63ea114056a4a140835d4a452933

- Switch to AUTORELEASE in PKG_RELEASE
This avoids cases when someone forgets to bump PKG_RELEASE

- Fixed SPDX License Identifier

- Changed package versioning
Before: vis_1440-2_arm_cortex-a9_vfpv3-d16.ipk
After: vis_2013-04-07-7710cce4-1_arm_cortex-a9_vfpv3-d16.ipk

- Drop not necessary rows
(Some of them were overwritting defaults and it is not necessary)
Downloaded tarball is ~2kB smaller

