### PR TITLE
prince: Makefile refactoring

### DIFF
--- a/prince/Makefile
+++ b/prince/Makefile
@@ -8,56 +8,55 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prince
-PKG_VERSION:=v0.4
-PKG_RELEASE:=2
+PKG_VERSION:=0.4
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/AdvancedNetworkingSystems/prince/archive/refs/tags/v$(PKG_VERSION).tar.gz?
+PKG_HASH:=9e3ce87343f5ea1d66757f8c704b62ff47d5eb245a191cf1e6a9ec106c5da90e
+
+PKG_MAINTAINER:=Gabriele Gemmi <gabriel@autistici.org>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_USE_MIPS16:=0
 
 # out of source build
 CMAKE_BINARY_SUBDIR:=build
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/prince-$(PKG_VERSION)
-PKG_MIRROR_HASH:=19a3cae09f28a5ef07fc0f5ff12cf62c776a94fbf1626336ab04951775c104de
-PKG_INSTALL:=0
-PKG_LICENSE:=MIT
-PKG_SOURCE:=prince-$(PKG_VERSION).tar.xz
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_SUBDIR:=prince-$(PKG_VERSION)
-PKG_SOURCE_URL:=https://github.com/AdvancedNetworkingSystems/prince.git
-PKG_SOURCE_VERSION:=v0.4
-PKG_USE_MIPS16:=0
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
 define Package/prince
-	SECTION :=net
-	CATEGORY :=Network
-	SUBMENU :=Routing and Redirection
-	Mantainer :=Gabriele Gemmi <gabriel@autistici.org>
-	TITLE :=Prince
-	URL :=https://github.com/AdvancedNetworkingSystems/prince
-	MENU :=0
-	DEPENDS := +libjson-c +libpthread
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  TITLE:=Prince
+  URL:=https://github.com/AdvancedNetworkingSystems/prince
+  DEPENDS:=+libjson-c +libpthread
 endef
 
 define Package/prince/description
-	Prince is an open source implementation of the PopRouting Algorithm.
-	It has been developed as a Google Summer of Code Project in collaboration with Freifunk and the University of Trento.
+  Prince is an open source implementation of the PopRouting Algorithm.
+  It has been developed as a Google Summer of Code Project in collaboration with Freifunk and the University of Trento.
 
-	Prince fetches topology data from a Link State routing daemon (OONF, OLSR, OSPF, etc),
-	calculates the betweenness centrality using the topology and then computes the
-	the timers' optimal values using these data. At the end of the computation the timers are pushed back to the routing daemon.
-	Since v0.4 it supports both OONF and OLSRd.
+  Prince fetches topology data from a Link State routing daemon (OONF, OLSR, OSPF, etc),
+  calculates the betweenness centrality using the topology and then computes the
+  the timers' optimal values using these data. At the end of the computation the timers are pushed back to the routing daemon.
+  Since v0.4 it supports both OONF and OLSRd.
 endef
 
 define Package/prince/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/prince $(1)/usr/bin/prince
-	$(INSTALL_BIN) ./files/prince.init $(1)/etc/init.d/prince
-	$(INSTALL_DATA) ./files/prince.conf $(1)/etc/prince.conf
+
+	$(INSTALL_DIR) $(1)/usr/lib
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/build/libprince_oonf.so $(1)/usr/lib
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/build/libprince_olsr.so $(1)/usr/lib
+	
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/prince.init $(1)/etc/init.d/prince
+	$(INSTALL_DATA) ./files/prince.conf $(1)/etc/prince.conf
 endef
 
 CFLAGS += $(TARGET_CFLAGS) $(TARGET_CPPFLAGS)


### PR DESCRIPTION
Maintainer: @gabri94
Compile tested: Turris Omnia, OpenWrt master, mvebu/cortex-a9
Run tested: N/A

Description:

- Use AUTORELEASE in PKG_RELEASE
- Use tarball instead of checkouting git
- Use two spaces instead of indentation
- In install section reorder it (first folder, then files and so on)
- Added LICENSE file

- Reorder things to be more consistent with others
