### PR TITLE
mcproxy: Makefile cleanup

### DIFF
--- a/mcproxy/Makefile
+++ b/mcproxy/Makefile
@@ -8,18 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mcproxy
-PKG_SOURCE_VERSION:=93b5ace42268160ebbfff4c61818fb15fa2d9b99
-PKG_VERSION:=2017-08-24-$(PKG_SOURCE_VERSION)
-PKG_RELEASE:=3
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/mcproxy/mcproxy.git
-PKG_MIRROR_HASH:=5779a78dedaef491825ada632fe6d8282067025dede41d0eede5c441893a2994
-PKG_MAINTAINER:=Steven Barth <cyrus@openwrt.org>
-PKG_LICENSE:=GPL-2.0+
+PKG_SOURCE_DATE:=2017-08-24
+PKG_SOURCE_VERSION:=93b5ace42268160ebbfff4c61818fb15fa2d9b99
+PKG_MIRROR_HASH:=d9f41f93d471b3c92debffe734f48f03f5c6c6e90bb173993f44b33e699387f9
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_MAINTAINER:=Steven Barth <cyrus@openwrt.org>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -29,14 +28,14 @@ define Package/mcproxy
   CATEGORY:=Network
   SUBMENU:=Routing and Redirection
   TITLE:=Multicast Proxy for IGMP/MLD
-  URL:=http://mcproxy.realmv6.org
+  URL:=https://mcproxy.realmv6.org
   DEPENDS:=+libpthread +libstdcpp @(!GCC_VERSION_4_4&&!GCC_VERSION_4_6)
 endef
 
 define Package/mcproxy/description
- mcproxy is a free & open source implementation of the IGMP/MLD proxy function (see  RFC 4605) for Linux systems.
- It operates on the kernel tables for multicast routing and allows for multiple instantiations,
- as well as dynamically changing downstream interfaces.
+  mcproxy is a free & open source implementation of the IGMP/MLD proxy function (see  RFC 4605) for Linux systems.
+  It operates on the kernel tables for multicast routing and allows for multiple instantiations,
+  as well as dynamically changing downstream interfaces.
 endef
 
 define Package/mcproxy/conffiles


### PR DESCRIPTION
Maintainer: is not active
Compile tested: Turris Omnia, OpenWrt master, mvebu_cortex-a9
Run tested: N/A

Description:
- Switched to AUTORELEASE
- Fixed SPDX License Identifier and added PKG_LICENSE_FILES
- Use HTTPS for project website
- Changed versioning
Before: mcproxy_2017-08-24-93b5ace42268160ebbfff4c61818fb15fa2d9b99-3_arm_cortex-a9_vfpv3-d16.ipk
After: mcproxy_2017-08-24-93b5ace4-1_arm_cortex-a9_vfpv3-d16.ipk

Downloaded tarball is smaller by 0,2 MB