### PR TITLE
minimalist-pcproxy: fix post install script

### DIFF
--- a/minimalist-pcproxy/files/minimalist-pcproxy.defaults
+++ b/minimalist-pcproxy/files/minimalist-pcproxy.defaults
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ `uci -q get upnpd.config._pcproxy_configured` = "1" ]
+if [ "`uci -q get upnpd.config._pcproxy_configured`" = "1" ]
 then
     exit
 fi


### PR DESCRIPTION
Maintainer: @sbyx 
Compile tested: Turris 1.1, powerpc8540, OpenWrt 21.02.2
Run tested: Turris 1.1, powerpc8540, OpenWrt master

Fixes: https://github.com/openwrt/routing/issues/149

Would be nice to remove backtics, but this is fine as it is.

This should be cherry-picked to OpenWrt 21.02 and OpenWrt 19.07 branches.
