### PR TITLE
olsrd: switch to firewall4

### DIFF
--- a/olsrd/Makefile
+++ b/olsrd/Makefile
@@ -34,7 +34,7 @@ endef
 define Package/olsrd
   $(call Package/olsrd/template)
   MENU:=1
-  DEPENDS:=+libpthread +libubus
+  DEPENDS:=+libpthread +libubus +iptables +ip6tables
 endef
 
 define Package/olsrd/conffiles


### PR DESCRIPTION
Firewall4 uses nftables instead of iptables. Use iptables-nft for installing smart-gw-rules.

Fixes: #731 ("Certain upstream switch to firewall4 aka nftables instead of iptables")