### PR TITLE
[21.02] cjdns: pass for some build warnings (#738)

### DIFF
--- a/cjdns/Makefile
+++ b/cjdns/Makefile
@@ -18,7 +18,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cjdns
 PKG_VERSION:=v21
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cjdelisle/cjdns/tar.gz/$(PKG_NAME)-$(PKG_VERSION)?
@@ -81,7 +81,7 @@ define Build/Compile
 	CC="$(TARGET_CC)" \
 	AR="$(TARGET_AR)" \
 	RANLIB="$(TARGET_RANLIB)" \
-	CFLAGS="$(TARGET_CFLAGS) -U_FORTIFY_SOURCE" \
+	CFLAGS="$(TARGET_CFLAGS) -U_FORTIFY_SOURCE -Wno-error=array-bounds -Wno-error=stringop-overflow" \
 	LDFLAGS="$(TARGET_LDFLAGS)" \
 	SYSTEM="linux" \
 	TARGET_ARCH="$(CONFIG_ARCH)" \


### PR DESCRIPTION
Compile time changes reviewed by cjd.
Due to stricter compiler(s) we do not
want to error for these warnings.

Caused by: ...reading "past the end"
of a struct, because the struct is
actually a header and the body is of
unknown size. Compilers got stricter
and this became a warning.

Signed-off-by: William Fleurant <meshnet@protonmail.com>
(cherry picked from commit 71c11ab1b7d7f6ca3219c1359e20b168ec1979c5)

