### PR TITLE
opennds: Release v9.7.0 (for 21.02)

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -6,40 +6,42 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
-PKG_FIXUP:=autoreconf
-PKG_VERSION:=9.6.0
+PKG_VERSION:=9.7.0
 PKG_RELEASE:=1
 
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
-PKG_SOURCE:=opennds-$(PKG_VERSION).tar.gz
-PKG_HASH:=90613e636c668a16eb9d6abfe19715f87cea7000383a53ad6719dec80ff966db
+PKG_HASH:=3059911743edeec7b89c289d40382696273646a632e2e7cdcb43067d0396b347
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
+
+PKG_FIXUP:=autoreconf
 PKG_BUILD_PARALLEL:=1
-PKG_LICENSE:=GPL-2.0+
 
 include $(INCLUDE_DIR)/package.mk
 
 define Package/opennds
-	SUBMENU:=Captive Portals
-	SECTION:=net
-	CATEGORY:=Network
-	DEPENDS:=+libpthread +iptables-mod-ipopt +libmicrohttpd-no-ssl
-	TITLE:=Open public network gateway daemon
-	URL:=https://github.com/opennds/opennds
-	CONFLICTS:=nodogsplash nodogsplash2
+  SUBMENU:=Captive Portals
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libpthread +iptables-mod-ipopt +libmicrohttpd-no-ssl
+  TITLE:=Open public network gateway daemon
+  URL:=https://github.com/opennds/opennds
+  CONFLICTS:=nodogsplash nodogsplash2
 endef
 
 define Package/opennds/description
-	openNDS is a Captive Portal solution that offers an instant way to provide restricted access to the Internet.
-	With little or no configuration, a dynamically generated and adaptive splash page sequence is automatically served.
-	Both client driven Captive Portal Detection (CPD) and gateway driven Captive Portal Identification (CPI - RFC 8910 and RFC 8908) are supported.
-	Internet access is granted by either a click to continue button, or after credential verification as a result of filling in a login form.
-	The package incorporates the FAS API allowing many flexible customisation options.
-	The creation of sophisticated third party authentication applications is fully supported.
-	Internet hosted https portals can be implemented with no security errors, to inspire maximum user confidence.
-	This version requires iptables (legacy).
+  openNDS is a Captive Portal solution that offers an instant way to provide restricted access to the Internet.
+  With little or no configuration, a dynamically generated and adaptive splash page sequence is automatically served.
+  Both client driven Captive Portal Detection (CPD) and gateway driven Captive Portal Identification (CPI - RFC 8910 and RFC 8908) are supported.
+  Internet access is granted by either a click to continue button, or after credential verification as a result of filling in a login form.
+  The package incorporates the FAS API allowing many flexible customisation options.
+  The creation of sophisticated third party authentication applications is fully supported.
+  Internet hosted https portals can be implemented with no security errors, to inspire maximum user confidence.
+  This release requires iptables(legacy)
 endef
 
 define Package/opennds/install
@@ -65,7 +67,6 @@ define Package/opennds/install
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/theme_user-email-login-basic.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/theme_user-email-login-custom-placeholders.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/get_client_interface.sh $(1)/usr/lib/opennds/
-	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/get_client_token.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/client_params.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/unescape.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/authmon.sh $(1)/usr/lib/opennds/


### PR DESCRIPTION
Maintainer: Rob White rob@blue-wave.net
Compile tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc
Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, x86-64, on 21.02.2

Description:
This version adds new functionality, and fixes some issues
 It requires iptables(legacy)

  * Fix - syntax error (missing comma) in awk command in bash on generic Linux [bluewavenet]
  * Add - option to append serial number suffix to gatewayname [bluewavenet]
  * Add - block use of ip aliases on gateway interface [doctor-ox] [bluewavenet]
  * Fix - ndsctl json syntax error [bluewavenet]
  * Add - check for null variables in key value pairs in MHD callbacks [bluewavenet]
  * Fix - changed some notice messages into debug messages [bluewavenet]
  * Fix - possible return of incorrect pid [doctor-ox] [bluewavenet]
  * Fix - possible abiguities resulting in failure to parse parameters correctly [bluewavenet]
  * Fix - Remove deprecated get_client_token.sh [bluewavenet]
  * Fix - Prevent possible malformed mac address returned from dhcpcheck() [doctor-ox] [bluewavenet]

Signed-off-by: Rob White <rob@blue-wave.net>
