### PR TITLE
[21.02] olsrd: set lqm via ipc

### DIFF
--- a/olsrd/src/src/ubus.h
+++ b/olsrd/src/src/ubus.h
@@ -2,7 +2,7 @@
     IPC integration of olsrd with OpenWrt.
 
     The ubus interface offers following functions:
-    - add_inteface '{"ifname":"wg_51820"}'
+    - add_inteface '{"ifname":"wg_51820", "lqm": "0.5"}'
     - del_inteface '{"ifname":"wg_51820"}'
 */
 


### PR DESCRIPTION
You can now give a lqm when adding an interface:
  ubus call olsrd add_interface '{"ifname":"wg_51821", "lqm":"0.5"}'

Signed-off-by: Nick Hainke <vincent@systemli.org>
(cherry picked from commit e3c68429239f77c895b32502e2609df8b72c6caa)
