### PR TITLE
naywatch: fix reboot_now

### DIFF
--- a/naywatch/files/naywatch.sh
+++ b/naywatch/files/naywatch.sh
@@ -81,7 +81,7 @@ no_neighbors() {
     fi
 
     if [ $USE_WATCHDOG -eq 0 ] && [ $NO_NEIGHBORS_COUNT -gt $MIN_KICK ]; then
-        reboot_now
+        reboot_now 10
     fi
 }
 


### PR DESCRIPTION
Naywatch should first try to reboot normally, and if that does not work
do a hard reboot. However, the hard reboot was never called.

Signed-off-by: Nick Hainke <vincent@systemli.org>
(cherry picked from commit 65f747a8bcf19e0271e6bbe04c2432f9a93cc406)
