### PR TITLE
opennds: avoid circular dependency

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
 PKG_VERSION:=9.7.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
@@ -27,7 +27,7 @@ define Package/opennds
   SUBMENU:=Captive Portals
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+iptables-nft +kmod-ipt-conntrack +kmod-ipt-nat +libmicrohttpd-no-ssl
+  DEPENDS:=@IPTABLES_NFTABLES +iptables-nft +kmod-ipt-conntrack +kmod-ipt-nat +libmicrohttpd-no-ssl
   TITLE:=Open public network gateway daemon
   URL:=https://github.com/opennds/opennds
   CONFLICTS:=nodogsplash nodogsplash2 iptables-legacy


### PR DESCRIPTION
Maintainer: @bluewavenet 
Compile tested: mediatek/mt7622, aarch64-cortexa53
Run tested: none

Description:
Have the package depend on `@IPTABLES_NFTABLES`, which is needed to be able to select `iptables-nft`.  It is also necessary to make that selection dependent on `@IPTABLES_NFTABLES` as well, so that the config generator understands it is a conditional selection.

With this change, the following two lines are added to the generated tmp/.config-package.in.in:
```
	depends on IPTABLES_NFTABLES
	select iptables-nft if IPTABLES_NFTABLES
```
This avoids the following error, whose message does not help much:
```
Collecting package info: done
tmp/.config-package.in:102128:error: recursive dependency detected!
tmp/.config-package.in:102128: 	symbol PACKAGE_iptables-legacy is selected by PACKAGE_iptables-nft
tmp/.config-package.in:102935: 	symbol PACKAGE_iptables-nft is selected by PACKAGE_opennds
tmp/.config-package.in:101158: 	symbol PACKAGE_opennds depends on PACKAGE_iptables-legacy
For a resolution refer to Documentation/kbuild/kconfig-language.rst
subsection "Kconfig recursive dependency limitations"
```
What you need to avoid is the selection of `iptables-nft` when `IPTABLES_NFTABLES` is not selected, since `iptables-nft` depends on `IPTABLES_NFTABLES`.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

