### PR TITLE
[22.03] opennds: Release v9.7.0 Backport

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
-PKG_VERSION:=9.6.0
-PKG_RELEASE:=3
+PKG_VERSION:=9.7.0
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=90613e636c668a16eb9d6abfe19715f87cea7000383a53ad6719dec80ff966db
+PKG_HASH:=3059911743edeec7b89c289d40382696273646a632e2e7cdcb43067d0396b347
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>
@@ -30,7 +30,7 @@ define Package/opennds
   DEPENDS:=+iptables-nft +kmod-ipt-conntrack +kmod-ipt-nat +libmicrohttpd-no-ssl
   TITLE:=Open public network gateway daemon
   URL:=https://github.com/opennds/opennds
-  CONFLICTS:=nodogsplash nodogsplash2
+  CONFLICTS:=nodogsplash nodogsplash2 iptables-legacy
 endef
 
 define Package/opennds/description
@@ -67,7 +67,6 @@ define Package/opennds/install
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/theme_user-email-login-basic.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/theme_user-email-login-custom-placeholders.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/get_client_interface.sh $(1)/usr/lib/opennds/
-	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/get_client_token.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/client_params.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/unescape.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/authmon.sh $(1)/usr/lib/opennds/


### PR DESCRIPTION
Maintainer: Rob White rob@blue-wave.net
Compile tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc
Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, x86-64, on snapshot

  * This version adds new functionality, and fixes some issues
  * Fix - syntax error (missing comma) in awk command in bash on generic Linux [bluewavenet]
  * Add - option to append serial number suffix to gatewayname [bluewavenet]
  * Add - block use of ip aliases on gateway interface [doctor-ox] [bluewavenet]
  * Fix - ndsctl json syntax error [bluewavenet]
  * Add - check for null variables in key value pairs in MHD callbacks [bluewavenet]
  * Fix - changed some notice messages into debug messages [bluewavenet]
  * Fix - possible return of incorrect pid [doctor-ox] [bluewavenet]
  * Fix - possible abiguities resulting in failure to parse parameters correctly [bluewavenet]
  * Fix - Remove deprecated get_client_token.sh [bluewavenet]
  * Fix - Prevent possible malformed mac address returned from dhcpcheck() [doctor-ox] [bluewavenet]

Signed-off-by: Rob White <rob@blue-wave.net>
