### PR TITLE
openwrt-22.03: batman-adv: compat: Add atomic mc_forwarding support for stable kernels

### DIFF
--- a/batman-adv/patches/0006-batman-adv-make-mc_forwarding-atomic.patch
+++ b/batman-adv/patches/0006-batman-adv-make-mc_forwarding-atomic.patch
@@ -1,0 +1,27 @@
+From: Eric Dumazet <edumazet@google.com>
+Date: Wed, 2 Mar 2022 20:05:13 +0100
+Subject: batman-adv: make mc_forwarding atomic
+
+This fixes minor data-races in ip6_mc_input() and
+batadv_mcast_mla_rtr_flags_softif_get_ipv6()
+
+Signed-off-by: Eric Dumazet <edumazet@google.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+[sven@narfation.org: Add ugly hack to get it building with old kernels]
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/56db7c0540e733a1f063ccd6bab1b537a80857eb
+
+--- a/net/batman-adv/multicast.c
++++ b/net/batman-adv/multicast.c
+@@ -134,7 +134,11 @@ static u8 batadv_mcast_mla_rtr_flags_sof
+ {
+ 	struct inet6_dev *in6_dev = __in6_dev_get(dev);
+ 
++#if LINUX_VERSION_IS_GEQ(5, 18, 0) // UGLY_HACK_NEW
++	if (in6_dev && atomic_read(&in6_dev->cnf.mc_forwarding))
++#else // UGLY_HACK_OLD
+ 	if (in6_dev && in6_dev->cnf.mc_forwarding)
++#endif // UGLY_HACK_STOP
+ 		return BATADV_NO_FLAGS;
+ 	else
+ 		return BATADV_MCAST_WANT_NO_RTR6;

--- a/batman-adv/patches/0007-batman-adv-compat-Add-atomic-mc_fowarding-support-fo.patch
+++ b/batman-adv/patches/0007-batman-adv-compat-Add-atomic-mc_fowarding-support-fo.patch
@@ -1,0 +1,23 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Fri, 15 Apr 2022 15:12:45 +0200
+Subject: batman-adv: compat: Add atomic mc_fowarding support for stable kernels
+
+Fixes: 56db7c0540e7 ("batman-adv: make mc_forwarding atomic")
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/350adcaec82fbaa358a2406343b6130ac8dad126
+
+--- a/net/batman-adv/multicast.c
++++ b/net/batman-adv/multicast.c
+@@ -134,7 +134,11 @@ static u8 batadv_mcast_mla_rtr_flags_sof
+ {
+ 	struct inet6_dev *in6_dev = __in6_dev_get(dev);
+ 
+-#if LINUX_VERSION_IS_GEQ(5, 18, 0) // UGLY_HACK_NEW
++#if (LINUX_VERSION_IS_GEQ(5, 4, 189) && LINUX_VERSION_IS_LESS(5, 5, 0)) || /* UGLY_HACK */ \
++    (LINUX_VERSION_IS_GEQ(5, 10, 111) && LINUX_VERSION_IS_LESS(5, 11, 0)) || /* UGLY_HACK */ \
++    (LINUX_VERSION_IS_GEQ(5, 15, 34) && LINUX_VERSION_IS_LESS(5, 16, 0)) || /* UGLY_HACK */ \
++    (LINUX_VERSION_IS_GEQ(5, 16, 20) && LINUX_VERSION_IS_LESS(5, 17, 0)) || /* UGLY_HACK */ \
++    LINUX_VERSION_IS_GEQ(5, 17, 3) // UGLY_HACK_NEW
+ 	if (in6_dev && atomic_read(&in6_dev->cnf.mc_forwarding))
+ #else // UGLY_HACK_OLD
+ 	if (in6_dev && in6_dev->cnf.mc_forwarding)


### PR DESCRIPTION
Maintainer: @simonwunderlich 
Compile tested: ipq40xx
Run tested: -

Description:


Eric Dumazet changed the mc_forwarding in commit 145c7a793838 ("ipv6: make mc_forwarding atomic") the type of mc_forwarding from __s32 to an atomic_t. This patch was then ported to various stable kernels.

This code change caused a FTBFS when in batman-adv when `CONFIG_BATMAN_ADV_MCAST` was activated. To work around this problem, provide a version for kernels with __s32 mc_forwarding and a version for kernel with atomic_t mc_forwarding.

Fixes: #850 