### PR TITLE
[21.02] babeld: update to 1.12

### DIFF
--- a/babeld/Makefile
+++ b/babeld/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=babeld
-PKG_VERSION:=1.11
+PKG_VERSION:=1.12
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.irif.fr/~jch/software/files/
-PKG_HASH:=99315aeaf2ea207f177c16855ffa34fc354af1b5988c070e0f2fca3a0d4d0fa5
+PKG_HASH:=832ef080c380ff6c0d715c6bf88ac22fcae87dc0f04566e60becdb8d871effb9
 
 PKG_MAINTAINER:=Gabriel Kerneis <gabriel@kerneis.info>, \
 	Baptiste Jonglez <openwrt-pkg@bitsofnetworks.org>, \

--- a/babeld/patches/600-add-ubus.patch
+++ b/babeld/patches/600-add-ubus.patch
@@ -9,7 +9,7 @@
  struct timeval now;
  
  unsigned char myid[8];
-@@ -518,6 +520,9 @@ main(int argc, char **argv)
+@@ -521,6 +523,9 @@ main(int argc, char **argv)
          }
      }
  
@@ -19,7 +19,7 @@
      init_signals();
      rc = resize_receive_buffer(1500);
      if(rc < 0)
-@@ -613,6 +618,8 @@ main(int argc, char **argv)
+@@ -616,6 +621,8 @@ main(int argc, char **argv)
                  FD_SET(local_sockets[i].fd, &readfds);
                  maxfd = MAX(maxfd, local_sockets[i].fd);
              }
@@ -28,7 +28,7 @@
              rc = select(maxfd + 1, &readfds, NULL, NULL, &tv);
              if(rc < 0) {
                  if(errno != EINTR) {
-@@ -681,6 +688,9 @@ main(int argc, char **argv)
+@@ -684,6 +691,9 @@ main(int argc, char **argv)
              i++;
          }
  
@@ -57,7 +57,7 @@
  static struct filter *input_filters = NULL;
  static struct filter *output_filters = NULL;
  static struct filter *redistribute_filters = NULL;
-@@ -1029,7 +1031,8 @@ parse_option(int c, gnc_t gnc, void *clo
+@@ -1036,7 +1038,8 @@ parse_option(int c, gnc_t gnc, void *clo
                strcmp(token, "daemonise") == 0 ||
                strcmp(token, "skip-kernel-setup") == 0 ||
                strcmp(token, "ipv6-subtrees") == 0 ||
@@ -67,7 +67,7 @@
          int b;
          c = getbool(c, &b, gnc, closure);
          if(c < -1)
-@@ -1047,6 +1050,8 @@ parse_option(int c, gnc_t gnc, void *clo
+@@ -1054,6 +1057,8 @@ parse_option(int c, gnc_t gnc, void *clo
              has_ipv6_subtrees = b;
          else if(strcmp(token, "reflect-kernel-metric") == 0)
              reflect_kernel_metric = b;


### PR DESCRIPTION
Changelog:

5 May 2022: babeld-1.12

  * Implement v4-via-v6 routing (RFC 9229), which allows a router with
    IPv4 addresses only to route IPv4.  Thanks to Théophile Bastian.
  * Enable extended Netlink acks when available.
    Thanks to Toke Høyland-Jørgensen.
  * Fix restoring of interface configuration to avoid unbounded memory
    consumption.  Thanks to andrew-hoff.
  * Fix handling of deny filters in the install chain.

Refreshed patches:
- 600-add-ubus.patch

