### PR TITLE
batman-adv: Fix build with kernel 5.15.38

### DIFF
--- a/batman-adv/src/compat-hacks.h
+++ b/batman-adv/src/compat-hacks.h
@@ -61,6 +61,8 @@ static inline void batadv_eth_hw_addr_set(struct net_device *dev,
 
 #if LINUX_VERSION_IS_LESS(5, 18, 0)
 
+#include <linux/netdevice.h>
+
 static inline int batadv_netif_rx(struct sk_buff *skb)
 {
 	if (in_interrupt())


### PR DESCRIPTION
Maintainer: @simonwunderlich 
Compile tested: mt7622

@ptpt52

The build failed in this kernel due to some missing implicit includes:

    build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_mt7622/batman-adv-2022.1/compat-hacks.h:64:42: warning: 'struct sk_buff' declared inside parameter list will not be visible outside of this definition or declaration
       64 | static inline int batadv_netif_rx(struct sk_buff *skb)
          |                                          ^~~~~~~
    build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_mt7622/batman-adv-2022.1/compat-hacks.h: In function 'batadv_netif_rx':
    build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_mt7622/batman-adv-2022.1/compat-hacks.h:66:13: error: implicit declaration of function 'in_interrupt' [-Werror=implicit-function-declaration]
      66 |         if (in_interrupt())
          |             ^~~~~~~~~~~~
    build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_mt7622/batman-adv-2022.1/compat-hacks.h:67:24: error: implicit declaration of function 'netif_rx' [-Werror=implicit-function-declaration]
       67 |                 return netif_rx(skb);
          |                        ^~~~~~~~
    build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_mt7622/batman-adv-2022.1/compat-hacks.h:69:24: error: implicit declaration of function 'netif_rx_ni' [-Werror=implicit-function-declaration]
       69 |                 return netif_rx_ni(skb);
          |                        ^~~~~~~~~~~
    In file included from <command-line>:
    ./include/linux/netdevice.h: At top level:
    build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_mt7622/batman-adv-2022.1/compat-hacks.h:71:18: error: conflicting types for 'batadv_netif_rx'; have 'int(struct sk_buff *)'
       71 | #define netif_rx batadv_netif_rx
          |                  ^~~~~~~~~~~~~~~
    ./include/linux/netdevice.h:4029:5: note: in expansion of macro 'netif_rx'
     4029 | int netif_rx(struct sk_buff *skb);
          |     ^~~~~~~~
    build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_mt7622/batman-adv-2022.1/compat-hacks.h:64:19: note: previous definition of 'batadv_netif_rx' with type 'int(struct sk_buff *)'
       64 | static inline int batadv_netif_rx(struct sk_buff *skb)
          |                   ^~~~~~~~~~~~~~~
    cc1: some warnings being treated as errors
