### PR TITLE
[21.02] babled: update to 1.12.1

### DIFF
--- a/babeld/Makefile
+++ b/babeld/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=babeld
-PKG_VERSION:=1.12
+PKG_VERSION:=1.12.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.irif.fr/~jch/software/files/
-PKG_HASH:=832ef080c380ff6c0d715c6bf88ac22fcae87dc0f04566e60becdb8d871effb9
+PKG_HASH:=9ab59d7ac741f3630df23f9c3b67c60294d8b34ab622398f9b89773a878ecb1e
 
 PKG_MAINTAINER:=Gabriel Kerneis <gabriel@kerneis.info>, \
 	Baptiste Jonglez <openwrt-pkg@bitsofnetworks.org>, \


### PR DESCRIPTION
Changelog:
916d3d9 Update CHANGES for babeld-1.12.1
3d8aec4 Schedule an interface check after adding an interface.
f13602b Split last PC into unicast and multicast values

Signed-off-by: Nick Hainke <vincent@systemli.org>
(cherry picked from commit 9028f67afd88bbd46edde265bfc77e705406cbc4)
