### PR TITLE
ci: Use openwrt/gh-action-sdk@v5

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -83,7 +83,7 @@ jobs:
           echo "PACKAGES=$PACKAGES" >> $GITHUB_ENV
 
       - name: Build
-        uses: openwrt/gh-action-sdk@v4
+        uses: openwrt/gh-action-sdk@v5
         env:
           ARCH: ${{ matrix.arch }}-${{ env.BRANCH }}
           FEEDNAME: packages_ci


### PR DESCRIPTION
The previous build errors with v5 have been fixed. This version builds
packages as a normal user instead of as root.