### PR TITLE
olsrd: Robustify default procd respawn_retry

### DIFF
--- a/olsrd/files/olsrd4.init
+++ b/olsrd/files/olsrd4.init
@@ -48,7 +48,7 @@ start_service() {
 
 	config_get _respawn_threshold procd respawn_threshold 3600
 	config_get _respawn_timeout procd respawn_timeout 15
-	config_get _respawn_retry procd respawn_retry 0
+	config_get _respawn_retry procd respawn_retry 5
 
 	procd_set_param command "$BIN"
 	procd_append_param command -f ${CONF}

--- a/olsrd/files/olsrd6.init
+++ b/olsrd/files/olsrd6.init
@@ -48,7 +48,7 @@ start_service() {
 
 	config_get _respawn_threshold procd _respawn_threshold 3600
 	config_get _respawn_timeout procd respawn_timeout 15
-	config_get _respawn_retry procd respawn_retry 0
+	config_get _respawn_retry procd respawn_retry 5
 
 	procd_set_param command "$BIN"
 	procd_append_param command -f ${CONF}


### PR DESCRIPTION
Should `olrsd` crash *just once* after starting less than 3600s ago,
it will never restart. Fix that by making `olsrd`'s `respawn_retry`
non-zero.

Signed-off-by: <hurricos@gmail.com>

Maintainer: @nhainke
Compile tested: Need I really compile-test a procd option change?
Run tested: 4 x Meraki MR16 @ OpenWrt 21.02.0 -- but with this change made in a `config procd 'procd'` section in `/etc/config/olsrd`, rather than in the init script of the package.
