### PR TITLE
[21.02] naywatch: add log when naywatch activates

### DIFF
--- a/naywatch/files/naywatch.sh
+++ b/naywatch/files/naywatch.sh
@@ -88,6 +88,9 @@ no_neighbors() {
 log "Naywatch Started!"
 
 neighbors() {
+    if [ $ACTIVE -eq 0 ]; then
+        log "Naywatch Activated!"
+    fi
     ACTIVE=1
     NO_NEIGHBORS_COUNT=0
     if [ $USE_WATCHDOG -eq 1 ]; then


### PR DESCRIPTION
Naywatch now prints
  naywatch: Naywatch Activated!
when becoming active.

Signed-off-by: Nick Hainke <vincent@systemli.org>
(cherry picked from commit 09d5ceb9230b907029a3e09858ef181ff85e3913)
