### PR TITLE
cjdns: support the supernodes feature

### DIFF
--- a/cjdns/Makefile
+++ b/cjdns/Makefile
@@ -18,7 +18,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cjdns
 PKG_VERSION:=v21.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cjdelisle/cjdns/tar.gz/$(PKG_NAME)-$(PKG_VERSION)?

--- a/cjdns/lua/cjdns/uci.lua
+++ b/cjdns/lua/cjdns/uci.lua
@@ -53,6 +53,10 @@ function UCI.get()
     obj.router.interface.tunDevice = config.tun_device
   end
 
+  cursor:foreach("cjdns", "supernodes", function(supernodes)
+    table.insert(obj.router.supernodes, supernodes.public_key)
+  end)
+
   for i,section in pairs(obj.security) do
     if type(section.seccomp) == "number" then
       obj.security[i].seccomp = tonumber(config.seccomp)

--- a/luci-app-cjdns/Makefile
+++ b/luci-app-cjdns/Makefile
@@ -18,7 +18,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-cjdns
 PKG_VERSION:=1.3
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_MAINTAINER:=William Fleurant <meshnet@protonmail.com>
 PKG_LICENSE:=GPL-3.0-or-later

--- a/luci-app-cjdns/luasrc/model/cbi/cjdns/peering.lua
+++ b/luci-app-cjdns/luasrc/model/cbi/cjdns/peering.lua
@@ -70,4 +70,13 @@ eth_peers:option(Value, "address", translate("MAC address")).datatype = "macaddr
 eth_peers:option(Value, "public_key", translate("Public key"))
 eth_peers:option(Value, "password", translate("Password"))
 
+-- Supernodes
+supernodes = m:section(TypedSection, "supernodes", translate("List of Supernodes"),
+  translate("If none are specified they'll be taken from your peers"))
+supernodes.anonymous = true
+supernodes.addremove = true
+supernodes.template  = "cbi/tblsection"
+
+supernodes:option(Value, "public_key", translate("Public Key")).size = 55
+
 return m


### PR DESCRIPTION
Maintainer: me
Compile tested: OpenWrt Trunk
Run tested: Tested on Raspi4 device with v21.1

Description: configure cjdns with a given list of supernodes peers