### PR TITLE
bird1: Add missing dependency on luci-compat

### DIFF
--- a/bird1-openwrt/bird1-ipv4-openwrt/Makefile
+++ b/bird1-openwrt/bird1-ipv4-openwrt/Makefile
@@ -84,7 +84,7 @@ define Package/$(luci)
   SUBMENU:=3. Applications
   MAINTAINER:=Eloi Carbo <eloicaso@openmailbox.org>
   URL:=https://github.com/eloicaso/bird-openwrt/
-  DEPENDS:=+$(BIRD_PKG)-uci +luci-base
+  DEPENDS:=+$(BIRD_PKG)-uci +luci-base +luci-compat
 endef
 
 define Package/$(luci)/description

--- a/bird1-openwrt/bird1-ipv6-openwrt/Makefile
+++ b/bird1-openwrt/bird1-ipv6-openwrt/Makefile
@@ -84,7 +84,7 @@ define Package/$(luci)
   SUBMENU:=3. Applications
   MAINTAINER:=Eloi Carbo <eloicaso@openmailbox.org>
   URL:=https://github.com/eloicaso/bird-openwrt/
-  DEPENDS:=+$(BIRD_PKG)-uci +luci-base
+  DEPENDS:=+$(BIRD_PKG)-uci +luci-base +luci-compat
 endef
 
 define Package/$(luci)/description


### PR DESCRIPTION
Maintainer: @eloicaso

See https://forum.openwrt.org/t/luci-app-bird1-ipv4-errors/70288
