### PR TITLE
batman-adv: update packages to version 2022.2

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alfred
-PKG_VERSION:=2022.1
+PKG_VERSION:=2022.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=3a0ac2bb26e0cb3f2732d4873669a0a22e9825e8f9a8e7abac986363f275097f
+PKG_HASH:=b79ba89569351969105bef43dab371a819c557c2330bb8fe4de0be60b135d129
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
 PKG_LICENSE:=GPL-2.0-only MIT

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
-PKG_VERSION:=2022.1
+PKG_VERSION:=2022.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=87e89a938971b862422681bb34104e9b2b4b6512d1d165de953630df38d61a68
+PKG_HASH:=5c6fd7a1f3764bdef629558088a8b4ed7ca19c62f9a66c5c341e56da26e165bb
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
-PKG_VERSION:=2022.1
+PKG_VERSION:=2022.2
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=6d041d3530abd4b249abf5a96fc2a2e241431bf9443b547fdb25a2d8fd329a40
+PKG_HASH:=8aca27c6f168b137a7ed7031d58169396c1a97f958c2ea95b9c30a9b92576fe0
 PKG_EXTMOD_SUBDIRS:=net/batman-adv
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>


### PR DESCRIPTION
Maintainer: @simonwunderlich 
Compile tested: ipq40xx
Run tested: ipq40xx

batman-adv
==========

* support latest kernels (4.9 - 5.19)

alfred
======

* support event notification via unix socket
* improve timing stability of transmitted announcement packets
* reduce socket handling overhead when many clients and interfaces