### PR TITLE
[22.03] opennds: Release v9.8.0

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
-PKG_VERSION:=9.7.0
-PKG_RELEASE:=2
+PKG_VERSION:=9.8.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=3059911743edeec7b89c289d40382696273646a632e2e7cdcb43067d0396b347
+PKG_HASH:=11f4a48ef62007f56376c32a028f19183452c62eee6fddcb11aafe822e5ff1b4
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>
@@ -30,7 +30,7 @@ define Package/opennds
   DEPENDS:=+iptables-nft +kmod-ipt-conntrack +kmod-ipt-nat +libmicrohttpd-no-ssl
   TITLE:=Open public network gateway daemon
   URL:=https://github.com/opennds/opennds
-  CONFLICTS:=nodogsplash nodogsplash2
+  CONFLICTS:=nodogsplash
 endef
 
 define Package/opennds/description
@@ -71,6 +71,7 @@ define Package/opennds/install
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/unescape.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/authmon.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/dnsconfig.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/download_resources.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/post-request.php $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-aes/fas-aes.php $(1)/etc/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-hid/fas-hid.php $(1)/etc/opennds/


### PR DESCRIPTION
Maintainer: Rob White rob@blue-wave.net
Compile tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, x86-64
Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, x86-64; on snapshot, 22.03

  * This version adds new functionality, and fixes some issues
  * Fix - suppress stderr in client_params in generic linux [bluewavenet]
  * Fix - client_params on generic linux, remote logo not supported yet [bluewavenet]
  * Fix - compiler warning [bluewavenet]
  * Fix - set voucher script as executable [bluewavenet]
  * Update OpenWrt Makefile [bluewavenet]
  * Add - format footer in Themespec scripts [bluewavenet]
  * Update footer on all scripts [bluewavenet]
  * Update - Community Voucher Themespec [bluewavenet]
  * Add - Check on startup for Y2.038K bug (32 bit time) [bluewavenet]
  * Fix - Remove deprecated Debian specific files [bluewavenet]
  * Add - More css updates [bluewavenet]
  * Add - user friendly RFC8910 page511 text and remove refresh button [bluewavenet]
  * Fix - MHD becomes unresponsive serving page 511 for rfc8910 clients [bluewavenet]
  * Add - extra startup settings - ignore_sigpipe and write nds info [bluewavenet]
  * Add - set MHD connection limit to 100, set MHD listen backlog size to 128, set MHD_HTTP_HEADER_CONNECTION "close" [bluewavenet]
  * Fix - Add missing LOG_CRIT in debug [bluewavenet]
  * Add - some useful diagnostic output in authmon [bluewavenet]
  * Fix - Move testing to community [bluewavenet]
  * Fix - Community - Use tmpfs by default for vouchers.txt file [bluewavenet]
  * Add - README with use instructions and notice about flash wearout [fservida]
  * Fix - Refactor folder structure for community themespec [fservida]
  * Add - Create vouchers.txt [fservida]
  * Add - Create theme_voucher.sh [fservida]
  * Update - README.md [bluewavenet]
  * Add - image download info message [bluewavenet]
  * Add - css updates [dianariyanto]
  * Add - allow downloaded remotes refresh for all modes [bluewavenet]
  * Add - download_resources.sh to installed files [bluewavenet]
  * Add - support for download of custom images and files in the status.client page [bluewavenet]
  * Remove - Debian man page support [bluewavenet]
  * Fix - Add missing mkdir command in Makefile [dzatoah]
  * Fix - typos in src/{conf, main}.c [dzatoah]

Signed-off-by: Rob White <rob@blue-wave.net>
(cherry picked from commit https://github.com/openwrt/routing/commit/b6f063dcca270f6c75287d1ffcbf148aba9427d2)