### PR TITLE
[22.03] mesh11sd: Release v1.2.0

### DIFF
--- a/mesh11sd/Makefile
+++ b/mesh11sd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mesh11sd
-PKG_VERSION:=1.1.1
+PKG_VERSION:=1.2.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>
@@ -17,7 +17,7 @@ PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/mesh11sd/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=61af46481facadf626bb1cc09c3bf2f2a9e1e9468145647ba5f5931b5f04ee98
+PKG_HASH:=b719eaacf63eb3684d0cd6a026f4357a4f400f2339f5d5a6cf74ba3744fe30d8
 PKG_BUILD_DIR:=$(BUILD_DIR)/mesh11sd-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: Rob White rob@blue-wave.net
Compile tested: All
Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, x86-64, on 21.02, 22.03 and snapshot.

Description:
  * This version adds new functionality.
  * Update README.md
  * Add - Traffic volume, Peers and stations to status output [bluewavenet]
  * Add - limit up-checks to mesh interfaces only [bluewavenet]

 -- Rob White <dot@blue-wave.net>  Mon, 08 Aug 2022 13:40:31 +0000

Signed-off-by: Rob White <rob@blue-wave.net>
(cherry picked from commit 290ed82bd8b8b2d4153721aa073456d5089da73b)
