### PR TITLE
opennds: Release v9.9.0

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
-PKG_VERSION:=9.8.0
+PKG_VERSION:=9.9.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=11f4a48ef62007f56376c32a028f19183452c62eee6fddcb11aafe822e5ff1b4
+PKG_HASH:=fd32ffce4a082ac0c40d4627fc1219b5c8cfcb5d73e70166bf3cf82cda91ac8e
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>
@@ -34,13 +34,10 @@ define Package/opennds
 endef
 
 define Package/opennds/description
-  openNDS is a Captive Portal solution that offers an instant way to provide restricted access to the Internet.
-  With little or no configuration, a dynamically generated and adaptive splash page sequence is automatically served.
-  Both client driven Captive Portal Detection (CPD) and gateway driven Captive Portal Identification (CPI - RFC 8910 and RFC 8908) are supported.
-  Internet access is granted by either a click to continue button, or after credential verification as a result of filling in a login form.
-  The package incorporates the FAS API allowing many flexible customisation options.
-  The creation of sophisticated third party authentication applications is fully supported.
-  Internet hosted https portals can be implemented with no security errors, to inspire maximum user confidence.
+  openNDS (open Network Demarcation Service) is a high performance, small footprint, Captive Portal.
+  It provides a border control gateway between a public local area network and the Internet.
+  It supports all ranges between small stand alone venues through to large mesh networks with multiple portal entry points.
+  Both the client driven Captive Portal Detection (CPD) method and gateway driven Captive Portal Identification method (CPI - RFC 8910 and RFC 8908) are supported.
   This version requires iptables-nft.
 endef
 


### PR DESCRIPTION
Maintainer: Rob White rob@blue-wave.net
Compile tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, x86-64 Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, x86-64; on snapshot, 22.03

opennds (9.9.0)

  * This version adds new functionality, and fixes some issues
  * Add - Community ThemeSpec to support legacy splash.html [bluewavenet]
  * Fix - ensure nat_traversal_poll_interval defaults to 10 seconds [bluewavenet]
  * Add - process send_to_fas_deauthed and send_to_fas_custom in fas-aes-https [bluewavenet]
  * Add - support for send_to_fas_deauthed library call in binauth_log.sh [bluewavenet]
  * Add - heartbeat file containing timestamp [bluewavenet]
  * Add - send_to_fas_deauthed and send_to_fas_custom library calls [bluewavenet]
  * Add - Save authmon daemon startup arguments for libopennds [bluewavenet]
  * Fix - potential divide by zero errors [bluewavenet]
  * Add - option nat_traversal_poll_interval [bluewavenet]
  * Add - Library calls for urlencode and urldecode[bluewavenet]
  * Fix - Don't download remotes if ThemeSpec not configured [bluewavenet]
  * Add - Error report in syslog if dhcp database is not found [bluewavenet]
  * Add - library calls, deauth and daemon_deauth [bluewavenet]
  * Fix - change WTERMSIG log from WARNING to NOTICE [bluewavenet]
  * Add - Set minimum bucket size to 5 regardless of configured bucket ratio [bluewavenet]
  * Fix - safe_vasprint return value [bluewavenet]
  * Add - test if safe_calloc failed and serve error 503 [bluewavenet]
  * Add - use calloc instead of malloc[bluewavenet]
  * fix - safe functions to return error rather than exit [bluewavenet]
  * Add - b64decode custom string received by binauth script [bluewavenet]

Signed-off-by: Rob White <rob@blue-wave.net>
