### PR TITLE
babeld: add del_filters function

### DIFF
--- a/babeld/patches/100-Add-functions-to-delete-filters-from-an-interface.patch
+++ b/babeld/patches/100-Add-functions-to-delete-filters-from-an-interface.patch
@@ -1,0 +1,65 @@
+From 7dc87f39dc5d1db7654f6ad89eca77766812affd Mon Sep 17 00:00:00 2001
+From: Nick Hainke <vincent@systemli.org>
+Date: Tue, 18 Oct 2022 21:34:03 +0200
+Subject: [PATCH] Add functions to delete filters from an interface
+
+Adding a delete function at runtime allows the babeld ipc to add and
+remove interfaces with filters. Further, it also allows more dynamic
+routing selection.
+
+Signed-off-by: Nick Hainke <vincent@systemli.org>
+---
+ configuration.c | 42 ++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 42 insertions(+)
+
+--- a/configuration.c
++++ b/configuration.c
+@@ -859,6 +859,48 @@ parse_key(int c, gnc_t gnc, void *closur
+     return -2;
+ }
+ 
++void
++delete_filters_from_interface(char* ifname, struct filter **filters)
++{
++    struct filter *f;
++
++    while(*filters && (*filters)->ifname && strcmp(ifname, (*filters)->ifname) == 0)
++    {
++        f = *filters;
++        *filters = f->next;
++        free(f);
++    }
++    
++    f = *filters;
++    while(f && f->next)
++    {
++        if(!f->next->ifname)
++        {
++            f = f->next;
++            continue;
++        }
++
++        if(strcmp(ifname, f->next->ifname) == 0)
++        {
++            struct filter *tmp;
++            tmp = f->next;
++            f->next = f->next->next;
++            free(tmp);
++        } else {
++            f = f->next;
++        }
++    }
++}
++
++void
++delete_all_filters_from_interface(char* ifname)
++{
++    delete_filters_from_interface(ifname, &input_filters);
++    delete_filters_from_interface(ifname, &output_filters);
++    delete_filters_from_interface(ifname, &redistribute_filters);
++    delete_filters_from_interface(ifname, &install_filters);
++}
++
+ int
+ add_filter(struct filter *filter, int type)
+ {

--- a/babeld/patches/600-add-ubus.patch
+++ b/babeld/patches/600-add-ubus.patch
@@ -57,7 +57,7 @@
  static struct filter *input_filters = NULL;
  static struct filter *output_filters = NULL;
  static struct filter *redistribute_filters = NULL;
-@@ -1036,7 +1038,8 @@ parse_option(int c, gnc_t gnc, void *clo
+@@ -1078,7 +1080,8 @@ parse_option(int c, gnc_t gnc, void *clo
                strcmp(token, "daemonise") == 0 ||
                strcmp(token, "skip-kernel-setup") == 0 ||
                strcmp(token, "ipv6-subtrees") == 0 ||
@@ -67,7 +67,7 @@
          int b;
          c = getbool(c, &b, gnc, closure);
          if(c < -1)
-@@ -1054,6 +1057,8 @@ parse_option(int c, gnc_t gnc, void *clo
+@@ -1096,6 +1099,8 @@ parse_option(int c, gnc_t gnc, void *clo
              has_ipv6_subtrees = b;
          else if(strcmp(token, "reflect-kernel-metric") == 0)
              reflect_kernel_metric = b;

--- a/babeld/src/ubus.c
+++ b/babeld/src/ubus.c
@@ -117,6 +117,30 @@ static int babeld_ubus_add_filter(struct ubus_context *ctx_local,
   return UBUS_STATUS_OK;
 }
 
+// Deletes filters for a given interface.
+static int babeld_ubus_del_filters(struct ubus_context *ctx_local,
+                                     struct ubus_object *obj,
+                                     struct ubus_request_data *req,
+                                     const char *method,
+                                     struct blob_attr *msg) {
+  struct blob_attr *tb[__INTERFACE_MAX];
+  struct blob_buf b = {0};
+  struct interface *ifp = NULL;
+  char *ifname;
+
+  blobmsg_parse(interface_policy, __INTERFACE_MAX, tb, blob_data(msg),
+                blob_len(msg));
+
+  if (!tb[INTERFACE_IFNAME])
+    return UBUS_STATUS_INVALID_ARGUMENT;
+
+  ifname = blobmsg_get_string(tb[INTERFACE_IFNAME]);
+
+  delete_all_filters_from_interface(ifname);
+
+  return UBUS_STATUS_OK;
+}
+
 // Adds an inteface (ubus equivalent to "interface"-function).
 static int babeld_ubus_add_interface(struct ubus_context *ctx_local,
                                      struct ubus_object *obj,
@@ -419,6 +443,7 @@ static int babeld_ubus_get_neighbours(struct ubus_context *ctx_local,
 static const struct ubus_method babeld_methods[] = {
     UBUS_METHOD("add_interface", babeld_ubus_add_interface, interface_policy),
     UBUS_METHOD("add_filter", babeld_ubus_add_filter, filter_policy),
+    UBUS_METHOD("del_filters", babeld_ubus_del_filters, interface_policy),
     UBUS_METHOD_NOARG("get_info", babeld_ubus_babeld_info),
     UBUS_METHOD_NOARG("get_xroutes", babeld_ubus_get_xroutes),
     UBUS_METHOD_NOARG("get_routes", babeld_ubus_get_routes),

--- a/babeld/src/ubus.h
+++ b/babeld/src/ubus.h
@@ -9,6 +9,7 @@
             2: FILTER_TYPE_REDISTRIBUTE
             3: FILTER_TYPE_INSTALL
     - add_interface '{"ifname":"eth0"}'
+    - del_filters '{"ifname":"eth0"}'
     - get_info
     - get_neighbours
     - get_xroutes


### PR DESCRIPTION
This commit adds the ubus function to dynamically delete filters on runtime:

  ubus call babeld del_filters '{"ifname":"eth0"}'

Maintainer: me, @kerneis 
Compile tested: belkin rt3200
Run tested: belkin rt3200
