### PR TITLE
batman-adv: update packages to version 2022.3

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alfred
-PKG_VERSION:=2022.2
+PKG_VERSION:=2022.3
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=b79ba89569351969105bef43dab371a819c557c2330bb8fe4de0be60b135d129
+PKG_HASH:=c03f1763b855e32cc2384eca9560e9609c96d9b01ef5375f28765cee18005112
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
 PKG_LICENSE:=GPL-2.0-only MIT

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
-PKG_VERSION:=2022.2
+PKG_VERSION:=2022.3
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=5c6fd7a1f3764bdef629558088a8b4ed7ca19c62f9a66c5c341e56da26e165bb
+PKG_HASH:=c58b371771d7cb9a8786d7394834f1ff8d45d415637a64e9076eaa0953b1f2d7
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
-PKG_VERSION:=2022.2
+PKG_VERSION:=2022.3
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=8aca27c6f168b137a7ed7031d58169396c1a97f958c2ea95b9c30a9b92576fe0
+PKG_HASH:=218ffb534fead1c9b5b0d90ec1b2fba688209cdf00e861bece1cbf469fe69953
 PKG_EXTMOD_SUBDIRS:=net/batman-adv
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/patches/0004-Revert-batman-adv-Migrate-to-linux-container_of.h.patch
+++ b/batman-adv/patches/0004-Revert-batman-adv-Migrate-to-linux-container_of.h.patch
@@ -117,11 +117,12 @@ This reverts commit 043ae5634bdfd4c4dd8b95a22890752495080bb5.
  #include <linux/gfp.h>
 --- a/net/batman-adv/hard-interface.c
 +++ b/net/batman-adv/hard-interface.c
-@@ -9,11 +9,11 @@
+@@ -9,12 +9,12 @@
  
  #include <linux/atomic.h>
  #include <linux/byteorder/generic.h>
 -#include <linux/container_of.h>
+ #include <linux/errno.h>
  #include <linux/gfp.h>
  #include <linux/if.h>
  #include <linux/if_arp.h>

--- a/batman-adv/src/compat-hacks.h
+++ b/batman-adv/src/compat-hacks.h
@@ -74,6 +74,14 @@ static inline int batadv_netif_rx(struct sk_buff *skb)
 
 #endif /* LINUX_VERSION_IS_LESS(5, 18, 0) */
 
+#if LINUX_VERSION_IS_LESS(6, 0, 0)
+
+#define __vstring(item, fmt, ap) __dynamic_array(char, item, 256)
+#define __assign_vstr(dst, fmt, va) \
+	WARN_ON_ONCE(vsnprintf(__get_dynamic_array(dst), 256, fmt, *va) >= 256)
+
+#endif /* LINUX_VERSION_IS_LESS(6, 0, 0) */
+
 /* <DECLARE_EWMA> */
 
 #include <linux/version.h>


### PR DESCRIPTION
Maintainer: @simonwunderlich 
Compile tested: ipq40xx
Run tested: ipq40xx

batman-adv
==========

* support latest kernels (4.9 - 6.1)
* coding style cleanups and refactoring
* bugs squashed:
  - limit the minimum MTU of hard-interface to avoid "Forced to purge local tt entries" errors

alfred
======

* coding style cleanups and refactoring