### PR TITLE
opennds: Release v9.9.1

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
-PKG_VERSION:=9.9.0
+PKG_VERSION:=9.9.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=fd32ffce4a082ac0c40d4627fc1219b5c8cfcb5d73e70166bf3cf82cda91ac8e
+PKG_HASH:=039c2228c83f9340e73c8b9410259a278d2880b442f2361f6d630e534baf7621
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>
@@ -36,8 +36,8 @@ endef
 define Package/opennds/description
   openNDS (open Network Demarcation Service) is a high performance, small footprint, Captive Portal.
   It provides a border control gateway between a public local area network and the Internet.
-  It supports all ranges between small stand alone venues through to large mesh networks with multiple portal entry points.
-  Both the client driven Captive Portal Detection (CPD) method and gateway driven Captive Portal Identification method (CPI - RFC 8910 and RFC 8908) are supported.
+  It supports all scenarios ranging from small stand alone venues through to large mesh networks with multiple portal entry points.
+  Both the client driven Captive Portal Detection method (CPD) and gateway driven Captive Portal Identification method (CPI - RFC 8910 and RFC 8908) are supported.
   This version requires iptables-nft.
 endef
 


### PR DESCRIPTION
Maintainer: Rob White rob@blue-wave.net
Compile tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, x86-64 Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, x86-64; on snapshot, 22.03

opennds (9.9.1)

  * This version fixes some issues
  * Fix - minimalise deprecated legacy .conf file
  * Fix - Prevent rate limit refresh if rate limit is set to 0 [bluewavenet]
  * Fix - Mute some unneccessary debug messages [bluewavenet]
  * Fix - do not write unconfigured (null) parameters to client id file (cidfile) [bluewavenet]
  * Fix - Prevent error "Command process exited due to signal 13" when executing an external script [bluewavenet]
  * Fix - use WTERMSIG() return code for _execute_ret when execute fails [bluewavenet]
  * Fix - use correct response type for error 503 [bluewavenet]
  * Update Makefile description [bluewavenet]
  * Add - Community Local FAS install script [bluewavenet]
  * Update - Mention TCP port 80 requires AutonomousWG [afriza]

Signed-off-by: Rob White <rob@blue-wave.net>
(cherry picked from commit 6c31b5bd1c5c27deff7bcb9393abd15f741606e8)
