### PR TITLE
oonf-olsrd2: fix building with multiple plugins - fixes #826

### DIFF
--- a/oonf-olsrd2/Makefile
+++ b/oonf-olsrd2/Makefile
@@ -17,8 +17,8 @@ CMAKE_INSTALL:=1
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
-SPACE:=
-SPACE+=
+# ref https://stackoverflow.com/a/10571900/3990041
+SPACE:= $(subst ,, )
 CMAKE_OPTIONAL_PLUGINS:= $(subst $(SPACE),;,$(strip \
         $(if $(filter y,$(CONFIG_OONF_NHDP_AUTOLL4)),auto_ll4,) \
         $(if $(filter y,$(CONFIG_OONF_OLSRV2_LAN_IMPORT)),lan_import,) \


### PR DESCRIPTION

Maintainer: HRogge 
Compile tested: mips24kc 22.03
Run tested: mips24kc 22.03

Description:
Code to replace colons wasn't working (debian stable)

Took it from stackoverflow, works now
