### PR TITLE
oonf-olsrd2: add missing static plugin olsrv2_lan

### DIFF
--- a/oonf-olsrd2/Config.in
+++ b/oonf-olsrd2/Config.in
@@ -44,4 +44,16 @@
 			The MPR plugin reduce the routing graph to limit the overhead of the OLSRv2 protocol
 		default n
 
+	config OONF_OLSRV2_LAN
+		bool "New config option for Locally attached entries"
+		help
+			Adds the 'lan' section to the config to configure LANs without setting multiple settings in a single key/value pair
+		default y
+
+	config OONF_OLSRV2_OLD_LAN
+		bool "Legacy option for Locally attached entries"
+		help
+			Adds the olsr 'lan' config key in the olsrv2 section
+		default n
+
 	endmenu

--- a/oonf-olsrd2/Makefile
+++ b/oonf-olsrd2/Makefile
@@ -27,6 +27,8 @@ CMAKE_OPTIONAL_PLUGINS:= $(subst $(SPACE),;,$(strip \
         $(if $(filter y,$(CONFIG_OONF_GENERIC_REMOTECONTROL)),remotecontrol,) \
         $(if $(filter y,$(CONFIG_OONF_OLSRV2_MPR)),mpr,) \
         $(if $(filter y,$(CONFIG_OONF_GENERIC_HTTP)),http,) \
+        $(if $(filter y,$(CONFIG_OONF_OLSRV2_LAN)),olsrv2_lan,) \
+        $(if $(filter y,$(CONFIG_OONF_OLSRV2_OLD_LAN)),olsrv2_old_lan,) \
     ))
 
 BUILD_TYPE:= $(if $(filter y,$(CONFIG_DEBUG)),Debug,Release)


### PR DESCRIPTION
Signed-off-by: Patrick Grimm <patrick@lunatiki.de>

Maintainer: @HRogge 
Compile tested: x86 ath79 ramips
Run tested: x86 ath79 ramips

Description:
oonf-olsrd2: add missing static plugin olsrv2_lan