### PR TITLE
oonf: fix IB warnings 'include file not found'

### DIFF
--- a/oonf-dlep-proxy/files/dlep_proxy.init
+++ b/oonf-dlep-proxy/files/dlep_proxy.init
@@ -3,4 +3,6 @@
 START=82
 DAEMON='dlep_proxy'
 
-. /lib/functions/oonf_init.sh
+[ -n "$IPKG_INSTROOT" ] || {
+        . /lib/functions/oonf_init.sh
+}

--- a/oonf-dlep-radio/files/dlep_radio.init
+++ b/oonf-dlep-radio/files/dlep_radio.init
@@ -3,4 +3,6 @@
 START=82
 DAEMON='dlep_radio'
 
-. /lib/functions/oonf_init.sh
+[ -n "$IPKG_INSTROOT" ] || {
+        . /lib/functions/oonf_init.sh
+}

--- a/oonf-olsrd2/files/olsrd2.init
+++ b/oonf-olsrd2/files/olsrd2.init
@@ -3,4 +3,6 @@
 START=82
 DAEMON='olsrd2'
 
-. /lib/functions/oonf_init.sh
+[ -n "$IPKG_INSTROOT" ] || {
+        . /lib/functions/oonf_init.sh
+}


### PR DESCRIPTION
Compile tested: mips_24kc, arm_cortex-a9_vfpv3-d16, i386_pentium4, x86_64, i386_pentium-mmx, mipsel_24kc

Signed-off-by: Patrick Grimm <patrick@lunatiki.de>
