### PR TITLE
bmx7: bump PKG_RELEASE for libiwinfo ABI change

### DIFF
--- a/bmx7/Makefile
+++ b/bmx7/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bmx7
 PKG_VERSION:=7.1.1
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/bmx-routing/bmx7/tar.gz/v$(PKG_VERSION)?


### PR DESCRIPTION
Bump PKG_RELEASE for libiwinfo ABI change for bmx7 package.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>