### PR TITLE
opennds: Release v9.10.0

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
-PKG_VERSION:=9.9.1
+PKG_VERSION:=9.10.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=039c2228c83f9340e73c8b9410259a278d2880b442f2361f6d630e534baf7621
+PKG_HASH:=0508a52ea6b2a18365ae071c623f923680bb926605f7b0678f14ea58bbfb2aba
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>


### PR DESCRIPTION
Maintainer: Rob White rob@blue-wave.net
Compile tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, x86-64 Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, x86-64; on snapshot, 22.03

opennds (9.10.0)

  * This version adds new functionality, and fixes some issues
  * Fix - unable to read client upload traffic volume on some versions of iptables-nft (generic Linux) [bluewavenet]
  * Fix - compatibility with bash shell on generic Linux [bluewavenet]
  * Fix - compiler warning, unused variable [bluewavenet]
  * Fix - silently continue if fw4 table is not found [bluewavenet]
  * Add - Start daemon earlier on boot [bluewavenet]
  * Fix - compatibility with legacy iptables packages [bluewavenet]
  * Add - call to delete nft chains [bluewavenet]
  * Fix - stop using legacy INPUT and FORWARD chains [bluewavenet]
  * Add - watchdog restart if openNDS nftables ruleset is missing [bluewavenet]
  * Add - automated rule setting/deleting for users_to_router [bluewavenet]
  * Add - Change fwhook to add users to router rule to fw4 on OpenWrt [bluewavenet]
  * Add - Set allow or passthrough mode for users_to_router rules [bluewavenet]
  * Fix - set fwhook default to disabled to prevent restart on hotplug event [bluewavenet]
  * Fix - fas-aes-https description comments [bluewavenet]
  * Fix - icon overspill on splash pages [bluewavenet]
  * Fix - missing config option in community script [bluewavenet]
  * Fix - urlencode handling of "$" character and add htmlentity encode/decode library call [bluewavenet]

Signed-off-by: Rob White <rob@blue-wave.net>
(cherry picked from commit 18168b34682cd7cd159c151c248350bc6f5649ff)
