### PR TITLE
batman-adv: update packages to version 2023.0

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alfred
-PKG_VERSION:=2022.3
+PKG_VERSION:=2023.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=c03f1763b855e32cc2384eca9560e9609c96d9b01ef5375f28765cee18005112
+PKG_HASH:=c5ecadce50e8228a912b4894567ad45d6ff1d2ba3991c978456e4bef9b7dbad1
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
 PKG_LICENSE:=GPL-2.0-only MIT

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
-PKG_VERSION:=2022.3
+PKG_VERSION:=2023.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=c58b371771d7cb9a8786d7394834f1ff8d45d415637a64e9076eaa0953b1f2d7
+PKG_HASH:=11071ec02b61e01e05ef8030b7bda8ff15e5c70b294a64204592c5b6cb31ed22
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
-PKG_VERSION:=2022.3
+PKG_VERSION:=2023.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=218ffb534fead1c9b5b0d90ec1b2fba688209cdf00e861bece1cbf469fe69953
+PKG_HASH:=2ce4ec04063252e7bfec3a2b3fa2a61b3b42c7b04d698ba60132bfab1d60a5cd
 PKG_EXTMOD_SUBDIRS:=net/batman-adv
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/src/compat-hacks.h
+++ b/batman-adv/src/compat-hacks.h
@@ -48,32 +48,6 @@ br_multicast_has_router_adjacent(struct net_device *dev, int proto)
 
 #endif /* LINUX_VERSION_IS_LESS(5, 14, 0) */
 
-#if LINUX_VERSION_IS_LESS(5, 15, 0)
-
-static inline void batadv_eth_hw_addr_set(struct net_device *dev,
-					  const u8 *addr)
-{
-	ether_addr_copy(dev->dev_addr, addr);
-}
-#define eth_hw_addr_set batadv_eth_hw_addr_set
-
-#endif /* LINUX_VERSION_IS_LESS(5, 15, 0) */
-
-#if LINUX_VERSION_IS_LESS(5, 18, 0)
-
-#include <linux/netdevice.h>
-
-static inline int batadv_netif_rx(struct sk_buff *skb)
-{
-	if (in_interrupt())
-		return netif_rx(skb);
-	else
-		return netif_rx_ni(skb);
-}
-#define netif_rx batadv_netif_rx
-
-#endif /* LINUX_VERSION_IS_LESS(5, 18, 0) */
-
 #if LINUX_VERSION_IS_LESS(6, 0, 0)
 
 #define __vstring(item, fmt, ap) __dynamic_array(char, item, 256)
@@ -81,6 +55,21 @@ static inline int batadv_netif_rx(struct sk_buff *skb)
 	WARN_ON_ONCE(vsnprintf(__get_dynamic_array(dst), 256, fmt, *va) >= 256)
 
 #endif /* LINUX_VERSION_IS_LESS(6, 0, 0) */
+
+#if LINUX_VERSION_IS_LESS(6, 2, 0)
+
+#include <linux/random.h>
+
+#define genl_split_ops genl_ops
+
+static inline u32 batadv_get_random_u32_below(u32 ep_ro)
+{
+	return prandom_u32_max(ep_ro);
+}
+
+#define get_random_u32_below batadv_get_random_u32_below
+
+#endif /* LINUX_VERSION_IS_LESS(6, 2, 0) */
 
 /* <DECLARE_EWMA> */
 


### PR DESCRIPTION
Maintainer: @simonwunderlich 
Compile tested: ipq40xx
Run tested: ipq40xx

batman-adv
==========

* support latest kernels (4.14 - 6.2)

alfred
======

* add support for gpsd 3.25