### PR TITLE
oonf-olsrd2: update to current develop branch - fixes routing#899

### DIFF
--- a/oonf-olsrd2/Makefile
+++ b/oonf-olsrd2/Makefile
@@ -6,8 +6,8 @@ PKG_RELEASE:=1
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/OLSR/OONF.git
 PKG_SOURCE_DATE:=2022-08-25
-PKG_SOURCE_VERSION:=fb15d54d6a7a087cb0c5ec37c49804f6ce432396
-PKG_MIRROR_HASH:=e8b2e7890f7315694649bb26c22be09554cba3724bae5419ea047101a4f5d03d
+PKG_SOURCE_VERSION:=1cec9b21086fb52ab4262c69aabd087e4d2d3a44
+PKG_MIRROR_HASH:=e9065af0a7103e84b9084683bb1db87c3361c1d97d8ad8a48a021b904b35ed56
 
 CMAKE_INSTALL:=1
 
@@ -20,7 +20,7 @@ CMAKE_OPTIONAL_PLUGINS:= $(subst $(SPACE),;,$(strip \
         $(if $(filter y,$(CONFIG_OONF_NHDP_AUTOLL4)),auto_ll4,) \
         $(if $(filter y,$(CONFIG_OONF_OLSRV2_LAN_IMPORT)),lan_import,) \
         $(if $(filter y,$(CONFIG_OONF_OLSRV2_ROUTE_MODIFIER)),route_modifier,) \
-        $(if $(filter y,$(CONFIG_OONF_GENERIC_DLEP_ROUTER)),dlep_router,) \
+        $(if $(filter y,$(CONFIG_OONF_GENERIC_DLEP_ROUTER)),dlep,) \
         $(if $(filter y,$(CONFIG_OONF_GENERIC_REMOTECONTROL)),remotecontrol,) \
         $(if $(filter y,$(CONFIG_OONF_OLSRV2_MPR)),mpr,) \
         $(if $(filter y,$(CONFIG_OONF_GENERIC_HTTP)),http,) \
@@ -36,13 +36,14 @@ CMAKE_OPTIONS+=-D CMAKE_BUILD_TYPE:String=$(BUILD_TYPE) \
                -D OONF_NO_TESTING:Bool=true \
                -D UCI:Bool=true \
                -D OONF_APP_DEFAULT_CFG_HANDLER:String=uci \
-               -D OONF_STATIC_PLUGINS:String="class;clock;duplicate_set;layer2;packet_socket;rfc5444;socket;stream_socket;telnet;timer;viewer;os_clock;os_fd;os_interface;os_routing;os_system;nhdp;olsrv2;ff_dat_metric;neighbor_probing;nl80211_listener;link_config;layer2info;systeminfo;cfg_uciloader;cfg_compact;nhdpinfo;olsrv2info;netjsoninfo;${CMAKE_OPTIONAL_PLUGINS}" \
+               -D OONF_STATIC_PLUGINS:String="class;callback;clock;duplicate_set;layer2;packet_socket;rfc5444;socket;stream_socket;telnet;timer;viewer;os_clock;os_fd;os_interface;os_routing;os_system;nhdp;olsrv2;ff_dat_metric;neighbor_probing;nl80211_listener;link_config;layer2info;systeminfo;cfg_uciloader;cfg_compact;nhdpinfo;olsrv2info;netjsoninfo;${CMAKE_OPTIONAL_PLUGINS}" \
                -D OONF_LIB_GIT:String=$(PKG_SOURCE_VERSION) \
                -D VERSION_SUB_TAG:String=$(PKG_SOURCE_DATE) \
                -D INSTALL_LIB_DIR:Path=lib/oonf \
                -D INSTALL_INCLUDE_DIR:Path=include/oonf \
                -D INSTALL_CMAKE_DIR:Path=lib/oonf \
-               -D CMAKE_PREFIX_PATH=$(STAGING_DIR)/usr
+               -D CMAKE_PREFIX_PATH=$(STAGING_DIR)/usr \
+               -D CMAKE_GENERATOR=Ninja
 
 define Package/oonf-git/template
 	SECTION:=net

--- a/oonf-olsrd2/patches/100-enable-lan-import-plugin.patch
+++ b/oonf-olsrd2/patches/100-enable-lan-import-plugin.patch
@@ -1,0 +1,8 @@
+--- a/src/olsrv2/CMakeLists.txt
++++ b/src/olsrv2/CMakeLists.txt
+@@ -6,4 +6,5 @@ add_subdirectory(olsrv2_old_lan)
+ add_subdirectory(olsrv2_l2import)
+ add_subdirectory(olsrv2_lan)
+ add_subdirectory(route_modifier)
++add_subdirectory(lan_import)
+ 


### PR DESCRIPTION
Development of OONF is very slow. The master branch is completely out of date and new releases haven't been tagged since 2018. According to this PR https://github.com/OLSR/OONF/pull/49#issuecomment-1229195523 the authors will probably just abandon the current master branch and replace it by the develop branch. During my testing, the current development branch is more stable than the latest tagged version on current OpenWrt versions.

Maintainer: me
Compile tested: Ubiquiti ER-X-SFP, MT7621 with both OpenWrt 22.03 and latest master.
Run tested: Ubiquiti ER-X-SFP, MT7621 with both OpenWrt 22.03 and latest master. 22.03 running stable since multiple weeks on my roof.
