### PR TITLE
treewide: refactor to use PKG_BUILD_FLAGS

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -15,6 +15,7 @@ PKG_LICENSE:=GPL-2.0-only MIT
 PKG_LICENSE_FILES:=LICENSES/preferred/GPL-2.0 LICENSES/preferred/MIT
 
 PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=gc-sections
 
 PKG_CONFIG_DEPENDS += \
 	CONFIG_ALFRED_NEEDS_lua \
@@ -67,8 +68,8 @@ MAKE_FLAGS += \
         LIBNL_GENL_NAME="libnl-tiny" \
         REVISION="$(PKG_VERSION)-openwrt-$(PKG_RELEASE)"
 
-TARGET_CFLAGS  += -ffunction-sections -fdata-sections -flto
-TARGET_LDFLAGS += -Wl,--gc-sections -fuse-linker-plugin
+TARGET_CFLAGS  += -flto
+TARGET_LDFLAGS += -fuse-linker-plugin
 
 define Package/alfred/install
 	$(INSTALL_DIR) $(1)/usr/sbin

--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -15,7 +15,7 @@ PKG_LICENSE:=GPL-2.0-only MIT
 PKG_LICENSE_FILES:=LICENSES/preferred/GPL-2.0 LICENSES/preferred/MIT
 
 PKG_BUILD_PARALLEL:=1
-PKG_BUILD_FLAGS:=gc-sections
+PKG_BUILD_FLAGS:=gc-sections lto
 
 PKG_CONFIG_DEPENDS += \
 	CONFIG_ALFRED_NEEDS_lua \
@@ -67,9 +67,6 @@ MAKE_FLAGS += \
         LIBNL_NAME="libnl-tiny" \
         LIBNL_GENL_NAME="libnl-tiny" \
         REVISION="$(PKG_VERSION)-openwrt-$(PKG_RELEASE)"
-
-TARGET_CFLAGS  += -flto
-TARGET_LDFLAGS += -fuse-linker-plugin
 
 define Package/alfred/install
 	$(INSTALL_DIR) $(1)/usr/sbin

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -16,6 +16,7 @@ PKG_LICENSE:=GPL-2.0-only ISC MIT
 PKG_LICENSE_FILES:=LICENSES/preferred/GPL-2.0 LICENSES/preferred/MIT LICENSES/deprecated/ISC
 
 PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=gc-sections
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -69,13 +70,6 @@ define Package/batctl-full/description
 $(Package/batctl/description)
   Subcommands for configuration, online and offline debugging are enabled.
 endef
-
-# The linker can identify unused sections of a binary when each symbol is stored
-# in a separate section. This mostly removes unused linker sections and reduces
-# the size by ~3% on mipsel.
-
-TARGET_CFLAGS  += -ffunction-sections -fdata-sections
-TARGET_LDFLAGS += -Wl,--gc-sections
 
 # Link-time optimization allows to move parts of the optimization from the single
 # source file to the global source view. This is done by emitting the GIMPLE

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -16,7 +16,7 @@ PKG_LICENSE:=GPL-2.0-only ISC MIT
 PKG_LICENSE_FILES:=LICENSES/preferred/GPL-2.0 LICENSES/preferred/MIT LICENSES/deprecated/ISC
 
 PKG_BUILD_PARALLEL:=1
-PKG_BUILD_FLAGS:=gc-sections
+PKG_BUILD_FLAGS:=gc-sections lto
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -70,13 +70,6 @@ define Package/batctl-full/description
 $(Package/batctl/description)
   Subcommands for configuration, online and offline debugging are enabled.
 endef
-
-# Link-time optimization allows to move parts of the optimization from the single
-# source file to the global source view. This is done by emitting the GIMPLE
-# representation in each object file and analyzing it again during the link step.
-
-TARGET_CFLAGS  += -flto
-TARGET_LDFLAGS += -fuse-linker-plugin
 
 MAKE_VARS += \
         LIBNL_NAME="libnl-tiny" \

--- a/prince/Makefile
+++ b/prince/Makefile
@@ -19,7 +19,7 @@ PKG_MAINTAINER:=Gabriele Gemmi <gabriel@autistici.org>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_USE_MIPS16:=0
+PKG_BUILD_FLAGS:=no-mips16
 
 # out of source build
 CMAKE_BINARY_SUBDIR:=build


### PR DESCRIPTION
This refactors packages to use the new PKG_BUILD_FLAGS feature added to the main repo.