### PR TITLE
cjdns: pass for dangling pointer warning

### DIFF
--- a/cjdns/Makefile
+++ b/cjdns/Makefile
@@ -81,7 +81,7 @@ define Build/Compile
 	CC="$(TARGET_CC)" \
 	AR="$(TARGET_AR)" \
 	RANLIB="$(TARGET_RANLIB)" \
-	CFLAGS="$(TARGET_CFLAGS) -U_FORTIFY_SOURCE -Wno-error=array-bounds -Wno-error=stringop-overflow -Wno-error=stringop-overread" \
+	CFLAGS="$(TARGET_CFLAGS) -U_FORTIFY_SOURCE -Wno-error=array-bounds -Wno-error=stringop-overflow -Wno-error=stringop-overread -Wno-error=dangling-pointer" \
 	LDFLAGS="$(TARGET_LDFLAGS)" \
 	SYSTEM="linux" \
 	TARGET_ARCH="$(CONFIG_ARCH)" \


### PR DESCRIPTION
Maintainer: @wfleurant 
Compile tested: builds for x86_64
Run tested: Build only testing

Description: same build error seen on my machine as seen in https://github.com/openwrt/routing/issues/958
Fix proposed is similar to https://github.com/openwrt/routing/issues/738
