### PR TITLE
batman-adv: fix compilation bug in batadv_is_cfg80211_netdev()

### DIFF
--- a/batman-adv/patches/0005-fix-batadv_is_cfg80211_netdev.patch
+++ b/batman-adv/patches/0005-fix-batadv_is_cfg80211_netdev.patch
@@ -1,0 +1,19 @@
+From: Alexandru Gagniuc <mr.nuke.me@gmail.com>
+Date: Thu, 6 Apr 2023 18:05:50 -0500
+Subject: fix batadv_is_cfg80211_netdev
+
+Replace CONFIG_CFG80211 with CPTCFG_CFG80211, which is the correct
+macro to use when building under backports.
+
+--- a/net/batman-adv/hard-interface.c
++++ b/net/batman-adv/hard-interface.c
+@@ -307,8 +307,7 @@ static bool batadv_is_cfg80211_netdev(st
+ {
+ 	if (!net_device)
+ 		return false;
+-
+-#if IS_ENABLED(CONFIG_CFG80211)
++#if IS_ENABLED(CPTCFG_CFG80211)
+ 	/* cfg80211 drivers have to set ieee80211_ptr */
+ 	if (net_device->ieee80211_ptr)
+ 		return true;


### PR DESCRIPTION
Maintainer: @simonwunderlich @ecsv
Compile tested: bcm2711
Run tested: bcm2711, start batman, enjoy a warning-free dmesg

Description:

Because batman-adv is built under backports, not a clean linux tree, the CONFIG_CFG80211 does not exist. The evaluation of IS_ENABLED() in batadv_is_cfg80211_netdev() will be false, causing the funtion to always return false.

This means that the wifi_flags of an interface don't get set, causing batadv_is_wifi_hardif() to always return false. As a result, batadv_v_elp_get_throughput() never tries to get the station info from cfg80211, resulting in the following warning:

    batman_adv: bat0: WiFi driver or ethtool info does not provide
    information about link speeds on interface phy1-mesh0,
    therefore defaulting to hardcoded throughput values of 1.0 Mbps.

So replace CONFIG_CFG80211 with CPTCFG_CFG80211, which is the correct macro to use under backports.