### PR TITLE
oonf-olsrd2: add support to check if service is running

### DIFF
--- a/oonf-init-scripts/files/oonf_init.sh
+++ b/oonf-init-scripts/files/oonf_init.sh
@@ -118,3 +118,20 @@ reload()
   oonf_add_devices_to_configuration
   oonf_reread_config
 }
+
+running()
+{
+  # check if we have a pidfile and then check if that pid still exists.
+  # since we don't use -e this has to be explicitly returned. exit would stop the process.
+  test -e "/tmp/run/olsrd2.pid" && test -e "/proc/$(cat "/tmp/run/olsrd2.pid")" && return 0
+  return 1
+}
+
+status()
+{
+  if running; then
+    echo "running"
+  else
+    echo "stopped"
+  fi
+}

--- a/oonf-olsrd2/Makefile
+++ b/oonf-olsrd2/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=oonf-olsrd2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/OLSR/OONF.git

--- a/oonf-olsrd2/files/olsrd2.init
+++ b/oonf-olsrd2/files/olsrd2.init
@@ -5,4 +5,7 @@ DAEMON='olsrd2'
 
 [ -n "$IPKG_INSTROOT" ] || {
         . /lib/functions/oonf_init.sh
+
+        extra_command "running" "Check if service is running"
+        extra_command "status" "Service status"
 }


### PR DESCRIPTION
Maintainer: @stargieg  / @XDjackieXD (find it by checking history of the package Makefile)
Compile tested: mips24k, master
Run tested: mips24k, ran service status / running commands

Description:
Adds the "running" and "status" commands.

Since olsr2 doesn't use procd, we need to add them by hand.