### PR TITLE
cjdns: patch of gyp imports support python3.10

### DIFF
--- a/cjdns/patches/040-gyp-python_310.patch
+++ b/cjdns/patches/040-gyp-python_310.patch
@@ -1,0 +1,15 @@
+--- a/node_build/dependencies/libuv/build/gyp/pylib/gyp/common.py
++++ b/node_build/dependencies/libuv/build/gyp/pylib/gyp/common.py
+@@ -4,7 +4,11 @@
+ 
+ from __future__ import with_statement
+ 
+-import collections
++try:
++  # Python 3.10
++  from six.moves import collections_abc as collections
++except ImportError:
++  import collections
+ import errno
+ import filecmp
+ import os.path


### PR DESCRIPTION
Maintainer: me
Compile tested: bpi
Run tested: no run 
Description: fixes dep issue for hosts building with python 3.10
