### PR TITLE
[22.03] opennds: Release v10.1.0

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
-PKG_VERSION:=9.10.0
+PKG_VERSION:=10.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=0508a52ea6b2a18365ae071c623f923680bb926605f7b0678f14ea58bbfb2aba
+PKG_HASH:=38527a437a1ae2190694f6f77f3b521b94cddd8151ce45c336b349e8fd1eb641
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>
@@ -27,8 +27,8 @@ define Package/opennds
   SUBMENU:=Captive Portals
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+iptables-nft +kmod-ipt-conntrack +kmod-ipt-nat +libmicrohttpd-no-ssl
-  TITLE:=Open public network gateway daemon
+  DEPENDS:=+libmicrohttpd-no-ssl
+  TITLE:=open Network Demarcation Service
   URL:=https://github.com/opennds/opennds
   CONFLICTS:=nodogsplash
 endef
@@ -38,7 +38,7 @@ define Package/opennds/description
   It provides a border control gateway between a public local area network and the Internet.
   It supports all scenarios ranging from small stand alone venues through to large mesh networks with multiple portal entry points.
   Both the client driven Captive Portal Detection method (CPD) and gateway driven Captive Portal Identification method (CPI - RFC 8910 and RFC 8908) are supported.
-  This version requires iptables-nft.
+  This version uses nftables.
 endef
 
 define Package/opennds/install
@@ -58,6 +58,7 @@ define Package/opennds/install
 	$(CP) $(PKG_BUILD_DIR)/linux_openwrt/opennds/files/etc/uci-defaults/40_opennds $(1)/etc/uci-defaults/
 	$(CP) $(PKG_BUILD_DIR)/linux_openwrt/opennds/files/usr/lib/opennds/restart.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/binauth/binauth_log.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/binauth/custombinauth.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/libopennds.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/theme_click-to-continue-basic.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/theme_click-to-continue-custom-placeholders.sh $(1)/usr/lib/opennds/


### PR DESCRIPTION

Maintainer: Rob White rob@blue-wave.net

Compile tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, x86-64

Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, x86-64; on snapshot, 23.05, 22.03

opennds (10.1.0)

  This version is a major upgrade including full migration to nftables
  and native uci configuration support even for generic Linux distributions.
  It also includes a significant refactoring of inbuilt memory management,
  improving long term reliability, fixing several memory leaks, buffer overflows and several edge case crashes.

  * Add - support for included custom binauth script [bluewavenet]
  * Add - emit a useful stderr message if auth_restore fails [bluewavenet]
  * Add - procd respawn threshold, respawn timeout and respawn retry parameters [bluewavenet]
  * Add - user friendly commandline message if already running [bluewavenet]
  * Fix - Enabling of Data volume quotas [bluewavenet]
  * Fix - use get_list_from_config instead of get_option_from_config [bluewavenet]
  * Fix - compiler warning - unused variable [bluewavenet]
  * Fix - remove redundant function call ipsetconf [bluewavenet]
  * Fix - walledgarden for both nftset and ipset on OpenWrt [bluewavenet]
  * Add - more meaningful output if attempt is made to restart when already running [bluewavenet]
  * Fix - resolve gatewayfqdn after startup [bluewavenet]
  * Fix - Choose forground or background running according to commandline arguments [bluewavenet]
  * Fix - remove superfluous debug message [bluewavenet]
  * Fix - replace sleep with procd_set_param term_timeout [bluewavenet]
  * Fix - make option enabled default to enabled [bluewavenet]
  * Fix - report authmon pid instead of opennds pid from authmon [bluewavenet]
  * Fix - ensure correct pid obtained for opennds [bluewavenet]
  * Add - StartLimitIntervalSec and StartLimitBurst to systemd service script [bluewavenet]
  * Fix - refactor remote downloads [bluewavenet]
  * Fix - suppress error message on ipset test failure [bluewavenet]
  * Fix - send non-syslog debug information to stdout by default [bluewavenet]
  * Add - C function to check heartbeat watchdog [bluewavenet]
  * Fix - Update generic Linux makefile [bluewavenet]
  * Fix - remove redundant ruleset struct definition [bluewavenet]
  * Fix - potential buffer overflow issue during config stage [bluewavenet]
  * Fix - remove unnecessary calls to free() in page 404 processing [bluewavenet]
  * Fix - remove redundant code from fw_iptables [bluewavenet]
  * Add - updates to binauth_log script [bluewavenet]
  * Add - updates for service startup, systemd and procd [bluewavenet]
  * Add - refactoring of commandline processing [bluewavenet]
  * Fix - remove debugging message [bluewavenet]
  * Fix - typo in client ruleset [bluewavenet]
  * Add - Refactor to use uci config directly even for Generic Linux [bluewavenet]
  * Add - Parsing for multi item lists with spaces in items [bluewavenet]
  * Add - use common library call get_option_fom_config [bluewavenet]
  * Add - support for direct use of uci format config file - string and integer parameters [bluewavenet]
  * Fix - Remove deprecated syslog_facility config setting [bluewavenet]
  * Add - thread busy message to ndsctl [bluewavenet]
  * Add - refactor configure_log_location [bluewavenet]
  * Fix - suppress LOG_NOTICE message when getting mac of interface [bluewavenet]
  * Fix - ndsctl error message [bluewavenet]
  * Fix - get_client_interface for levels 2 and 3 [bluewavenet]
  * Add - use common library write_log function [bluewavenet]
  * Add - Refactor memory management [bluewavenet]
  * Fix - fix and refactor upload rate limiting rules [bluewavenet]
  * Fix - Change a debug message from err to info [bluewavenet]
  * Add - refine common buffer sizes [bluewavenet]
  * Add - use initialised heap memory for redirect_to_splashpage [bluewavenet]
  * Add - user message to themespec [bluewavenet]
  * Add - auth_restore support ie reauth clients after a restart by default. [bluewavenet]
  * Add - Library call to preemptively re-auth clients after a restart or crash [bluewavenet]
  * Add - BinAuth, write an authenticated clients list [bluewavenet]
  * Add - library call "check_heartbeat" [bluewavenet]
  * Fix - Tidy up redundant code [bluewavenet]
  * Fix - change warning message to debug message when iw not installed [bluewavenet]
  * Add - library call to log to syslog [bluewavenet]
  * Fix - use initialised heap memory for client list entries [bluewavenet]
  * Fix - ignore legacy ipset firewall rule [bluewavenet]
  * Fix - refactor memory management for MHD calls - use heap memory for buffers etc [bluewavenet]
  * Fix - missing free causing memory leak [bluewavenet]
  * Fix  - predefine and initialise buffer for send_redirect_temp [bluewavenet]
  * Add - support protocol "all" in firewall ruleset [bluewavenet]
  * Add - pre-allocation of initialised buffers [bluewavenet]
  * Fix  - prevent buffer overrun on removing client [bluewavenet]
  * Add - update MHD connection timeout and connection limit [bluewavenet]
  * Add - chain ndsDLR for dynamic client download rate limiting rules [bluewavenet]
  * Add - Use Internal Polling Thread / Thread Per Connection in MHD [bluewavenet]
  * Add - some new default values [bluewavenet]
  * Fix - remove some redundant code and fix some compiler warnings [bluewavenet]
  * Fix - remove redundant library command string [bluewavenet]
  * Fix - Tidy up redundant iptables code [bluewavenet]
  * Add - convert trusted client support to nftables [bluewavenet]
  * Add - refer to nftables [bluewavenet]
  * Add - move code for generating authentication mark string to initial setup [bluewavenet]
  * Add - full nftset support with ipset import where required [bluewavenet]
  * Add - nftset support library calls [bluewavenet]
  * Add - ipset_to_nftset library call [bluewavenet]
  * Add - support for nftables version of append_ruleset and nftables_compile [bluewavenet]
  * Fix - buffer overflow in page_511 generation [bluewavenet]
  * Add - more nftables migration including rate quotas [bluewavenet]
  * Fix - change GatewayInterface to lower case [bluewavenet]
  * Add - upload and download limiting client flags for future use [bluewavenet]
  * add - lib calls "pad_string" and "replace_client_rule" [bluewavenet]
  * Add - further nftables migration [bluewavenet]
  * Fix - correctly parse options from legacy conf file [bluewavenet]
  * Fix - some compiler warnings and set min iptables version [bluewavenet]
  * Add - Generic Linux configure walledgarden [bluewavenet]
  * Add - Implementation of nftsets for walledgarden [bluewavenet]
  * Add - migration to nftables, next phase. [bluewavenet]
  * Add - library function delete_client_rule [bluewavenet]
  * Fix - remove duplicate definition [bluewavenet]
  * Add - First stage migration to nftables [bluewavenet]

Signed-off-by: Rob White <rob@blue-wave.net>
(cherry picked from commit 7b1911020b335492ecfd02f39fb0a4f1911b23db)
