### PR TITLE
[22.03] opennds: Release v10.1.1

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
-PKG_VERSION:=10.1.0
+PKG_VERSION:=10.1.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=38527a437a1ae2190694f6f77f3b521b94cddd8151ce45c336b349e8fd1eb641
+PKG_HASH:=60ce15f5aa96f7e7f3b239a0029f74c0ba900d3db72b209ba6e6d36a5bbef138
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>


### PR DESCRIPTION
Maintainer: Rob White rob@blue-wave.net

Compile tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, x86-64

Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, x86-64; on snapshot, 23.05, 22.03

Description:
opennds (10.1.1)
  * This version contains some minor bug fixes and documentation updates
  * Fix - send only contents of buffer, not entire buffer when serving page511 [bluewavenet]
  * Fix - Set fas_remotefqdn to gw_fqdn when overriding FAS settings [bluewavenet]
  * Fix - use absolute path for css and images in ThemeSpec [bluewavenet]
  * Fix - revert to old option names without underscores [bluewavenet]
  * Fix - FAS URL when fas_remotefqdn is not set [bluewavenet]

Signed-off-by: Rob White <rob@blue-wave.net>
(cherry picked from commit 26f5f0f812c73a3d26f9643fbd3da7f56f5e9a8a)
