### PR TITLE
babeld: update to 1.13

### DIFF
--- a/babeld/Makefile
+++ b/babeld/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=babeld
-PKG_VERSION:=1.12.2
+PKG_VERSION:=1.13
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.irif.fr/~jch/software/files/
-PKG_HASH:=1db22b6193070ea2450a1ab51196fd72f58a1329f780cb0388e2e4b2e7768cbb
+PKG_HASH:=d085ccccfb06a11d7fa5b54c51d9c410f5f3b0a9389f584951336ff178f293b8
 
 PKG_MAINTAINER:=Gabriel Kerneis <gabriel@kerneis.info>, \
 	Baptiste Jonglez <openwrt-pkg@bitsofnetworks.org>, \

--- a/babeld/patches/100-local-make-local_kind-function-accessible.patch
+++ b/babeld/patches/100-local-make-local_kind-function-accessible.patch
@@ -1,0 +1,39 @@
+From b29cb705c3b717a7d5c61719936464438b9a48f0 Mon Sep 17 00:00:00 2001
+From: Nick Hainke <vincent@systemli.org>
+Date: Fri, 15 Jan 2021 15:01:31 +0100
+Subject: [PATCH] local: make local_kind function accessible
+
+The kind-definitions are contained in the header file:
+  LOCAL_FLUSH 0
+  LOCAL_ADD 1
+  LOCAL_CHANGE 2
+
+The function (local_kind) that converts them into strings again
+is private. New addons (for example openwrt ubus bindings) that make
+use of babeld should also use the same function to convert the kind
+to string format. This allows to ensure uniformity over all addons.
+
+Signed-off-by: Nick Hainke <vincent@systemli.org>
+---
+ local.c | 2 +-
+ local.h | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+--- a/local.c
++++ b/local.c
+@@ -80,7 +80,7 @@ write_timeout(int fd, const void *buf, i
+     }
+ }
+ 
+-static const char *
++const char *
+ local_kind(int kind)
+ {
+     switch(kind) {
+--- a/local.h
++++ b/local.h
+@@ -55,3 +55,4 @@ int local_read(struct local_socket *s);
+ int local_header(struct local_socket *s);
+ struct local_socket *local_socket_create(int fd);
+ void local_socket_destroy(int i);
++const char *local_kind(int kind);

--- a/babeld/patches/600-add-ubus.patch
+++ b/babeld/patches/600-add-ubus.patch
@@ -9,7 +9,7 @@
  struct timeval now;
  
  unsigned char myid[8];
-@@ -521,6 +523,9 @@ main(int argc, char **argv)
+@@ -505,6 +507,9 @@ main(int argc, char **argv)
          }
      }
  
@@ -19,7 +19,7 @@
      init_signals();
      rc = resize_receive_buffer(1500);
      if(rc < 0)
-@@ -616,6 +621,8 @@ main(int argc, char **argv)
+@@ -597,6 +602,8 @@ main(int argc, char **argv)
                  FD_SET(local_sockets[i].fd, &readfds);
                  maxfd = MAX(maxfd, local_sockets[i].fd);
              }
@@ -28,7 +28,7 @@
              rc = select(maxfd + 1, &readfds, NULL, NULL, &tv);
              if(rc < 0) {
                  if(errno != EINTR) {
-@@ -684,6 +691,9 @@ main(int argc, char **argv)
+@@ -665,6 +672,9 @@ main(int argc, char **argv)
              i++;
          }
  
@@ -57,7 +57,7 @@
  static struct filter *input_filters = NULL;
  static struct filter *output_filters = NULL;
  static struct filter *redistribute_filters = NULL;
-@@ -1036,7 +1038,8 @@ parse_option(int c, gnc_t gnc, void *clo
+@@ -1017,7 +1019,8 @@ parse_option(int c, gnc_t gnc, void *clo
                strcmp(token, "daemonise") == 0 ||
                strcmp(token, "skip-kernel-setup") == 0 ||
                strcmp(token, "ipv6-subtrees") == 0 ||
@@ -67,7 +67,7 @@
          int b;
          c = getbool(c, &b, gnc, closure);
          if(c < -1)
-@@ -1054,6 +1057,8 @@ parse_option(int c, gnc_t gnc, void *clo
+@@ -1035,6 +1038,8 @@ parse_option(int c, gnc_t gnc, void *clo
              has_ipv6_subtrees = b;
          else if(strcmp(token, "reflect-kernel-metric") == 0)
              reflect_kernel_metric = b;

--- a/babeld/src/ubus.c
+++ b/babeld/src/ubus.c
@@ -245,23 +245,6 @@ static int babeld_ubus_get_xroutes(struct ubus_context *ctx_local,
 static void babeld_add_route_buf(struct babel_route *route,
                                  struct blob_buf *b) {
   void *prefix;
-  char channels[100];
-
-  if (route->channels_len == 0) {
-    channels[0] = '\0';
-  } else {
-    int i, j = 0;
-    snprintf(channels, sizeof(channels), " chan (");
-    j = strlen(channels);
-    for (i = 0; i < route->channels_len; i++) {
-      if (i > 0)
-        channels[j++] = ',';
-      snprintf(channels + j, sizeof(channels) - j, "%u",
-               (unsigned)route->channels[i]);
-      j = strlen(channels);
-    }
-    snprintf(channels + j, sizeof(channels) - j, ")");
-  }
 
   prefix = blobmsg_open_table(
       b, format_prefix(route->src->prefix, route->src->plen));
@@ -274,7 +257,6 @@ static void babeld_add_route_buf(struct babel_route *route,
   blobmsg_add_u32(b, "refmetric", route->refmetric);
   blobmsg_add_string(b, "id", format_eui64(route->src->id));
   blobmsg_add_u32(b, "seqno", (uint32_t)route->seqno);
-  blobmsg_add_string(b, "channels", channels);
   blobmsg_add_u32(b, "age", (int)(now.tv_sec - route->time));
   blobmsg_add_string(b, "via", format_address(route->neigh->address));
   if (memcmp(route->nexthop, route->neigh->address, 16) != 0)
@@ -357,7 +339,6 @@ static void babeld_add_neighbour_buf(struct neighbour *neigh,
   blobmsg_add_u32(b, "rxcost", neighbour_rxcost(neigh));
   blobmsg_add_u32(b, "txcost", neigh->txcost);
   blobmsg_add_string(b, "rtt", format_thousands(neigh->rtt));
-  blobmsg_add_u32(b, "channel", neigh->ifp->channel);
   blobmsg_add_u8(b, "if_up", if_up(neigh->ifp));
   blobmsg_close_table(b, neighbour);
 }


### PR DESCRIPTION
Announcement:
https://alioth-lists.debian.net/pipermail/babel-users/2023-July/004100.html

Babeld removed diversity routing [0], so we need to adjust ubus bindings. Further. we need to add a patch that makes local_kind accessible again: "100-local-make-local_kind-function-accessible.patch"

Refresh patches:
- 600-add-ubus.patch

[0] - https://github.com/jech/babeld/commit/a0816083356e5d33fb71e0e30d92aa3bf335d7ea

Maintainer: me
Compile tested: mt7621, mt7622
Run tested: mt7622
