### PR TITLE
opennds: Release v10.1.2

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
-PKG_VERSION:=10.1.1
+PKG_VERSION:=10.1.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=60ce15f5aa96f7e7f3b239a0029f74c0ba900d3db72b209ba6e6d36a5bbef138
+PKG_HASH:=818c24a8704e584665b493857086bccc3c55629977841ddffc185f7d082ef279
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>
@@ -30,7 +30,6 @@ define Package/opennds
   DEPENDS:=+libmicrohttpd-no-ssl
   TITLE:=open Network Demarcation Service
   URL:=https://github.com/opennds/opennds
-  CONFLICTS:=nodogsplash
 endef
 
 define Package/opennds/description
@@ -66,7 +65,6 @@ define Package/opennds/install
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/theme_user-email-login-custom-placeholders.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/get_client_interface.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/client_params.sh $(1)/usr/lib/opennds/
-	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/unescape.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/authmon.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/dnsconfig.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/download_resources.sh $(1)/usr/lib/opennds/

--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -30,6 +30,7 @@ define Package/opennds
   DEPENDS:=+libmicrohttpd-no-ssl
   TITLE:=open Network Demarcation Service
   URL:=https://github.com/opennds/opennds
+  CONFLICTS:=nodogsplash
 endef
 
 define Package/opennds/description


### PR DESCRIPTION
Maintainer: Rob White rob@blue-wave.net

Compile tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, x86-64

Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, x86-64; on snapshot, 23.05, 22.03

Description:
opennds (10.1.2)

Security Advisory - This version contains fixes for multiple potential security vulnerabilities
Credit - Stanislav Dashevskyi - standash.github.io [standash]
It also contains some minor bug fixes
  * Fix - Generate unique sha256 faskey if not set in config - CVE-2023-38324 [bluewavenet]
  * Fix - NULL pointer dereference if user_agent is NULL - CVE-2023-38320, CVE-2023-38322 [bluewavenet]
  * Fix - NULL pointer dereference if authdir is called with an incomplete or missing query string - CVE-2023-38313, CVE-2023-38314, CVE-2023-38315 [bluewavenet]
  * Fix - remove deprecated and non-functioning unescape callback - CVE-2023-38316 [bluewavenet]
  * Fix - prevent potential recursive dependency and detect if conflicting package is installed  (in addition to the `CONFLICTS: nodogsplash` line in the makefile, code was added to check for the presence of nodogsplash on opennds startup) [bluewavenet]

Signed-off-by: Rob White <rob@blue-wave.net>