### PR TITLE
batman-adv: update packages to version 2023.2

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alfred
-PKG_VERSION:=2023.1
+PKG_VERSION:=2023.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=438048248f373757d3a8bde7cbc6db6685f4d0105d130da2f5a54f29090c6974
+PKG_HASH:=a9206028564f89e5bfb7714ae29883a1610f62be3e61c096e1feb36200718e0e
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
 PKG_LICENSE:=GPL-2.0-only MIT

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
-PKG_VERSION:=2023.1
+PKG_VERSION:=2023.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=e5bf47305d955abb199244bd0e5fffab96108b1affabd0d9705533f8059395f1
+PKG_HASH:=70b5f931fa636325697bdf36f6d134a03c4906f4c17cb7650a3c714901436ec8
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
-PKG_VERSION:=2023.1
-PKG_RELEASE:=2
+PKG_VERSION:=2023.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=f46a7286660a5ec3506a1be7ef60b471c51ac70550597d598040479ab7b936b8
+PKG_HASH:=3907dcd57e2c5bfd9d40713960b9402bf1da4f80c59b5ff037789fbbbbd8fa25
 PKG_EXTMOD_SUBDIRS:=net/batman-adv
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>


### PR DESCRIPTION
Maintainer: @simonwunderlich 
Compile tested: x86_64
Run tested: x86_64

batman-adv
==========

* support latest kernels (4.14 - 6.5)
* bugs squashed:
  - avoid potential invalid memory access when processing ELP/OGM2 packets
  - drop pending DAT worker when interface shuts down
  - inform network stack about automatically adjusted MTUs
  - keep user defined MTU limit when MTU is recalculated
  - fix packet memory leak when sending OGM2 via inactive interfaces
  - fix TT memory leak for roamed back clients

alfred
======

* receive data with valid source on unix sock without active interface