### PR TITLE
openwrt-23.05: batman-adv: Merge bugfixes from 2023.2

### DIFF
--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
 PKG_VERSION:=2023.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)

--- a/batman-adv/patches/0003-batman-adv-Broken-sync-while-rescheduling-delayed-wo.patch
+++ b/batman-adv/patches/0003-batman-adv-Broken-sync-while-rescheduling-delayed-wo.patch
@@ -1,0 +1,48 @@
+From: Vladislav Efanov <VEfanov@ispras.ru>
+Date: Fri, 26 May 2023 19:16:32 +0300
+Subject: batman-adv: Broken sync while rescheduling delayed work
+
+Syzkaller got a lot of crashes like:
+KASAN: use-after-free Write in *_timers*
+
+All of these crashes point to the same memory area:
+
+The buggy address belongs to the object at ffff88801f870000
+ which belongs to the cache kmalloc-8k of size 8192
+The buggy address is located 5320 bytes inside of
+ 8192-byte region [ffff88801f870000, ffff88801f872000)
+
+This area belongs to :
+        batadv_priv->batadv_priv_dat->delayed_work->timer_list
+
+The reason for these issues is the lack of synchronization. Delayed
+work (batadv_dat_purge) schedules new timer/work while the device
+is being deleted. As the result new timer/delayed work is set after
+cancel_delayed_work_sync() was called. So after the device is freed
+the timer list contains pointer to already freed memory.
+
+Found by Linux Verification Center (linuxtesting.org) with syzkaller.
+
+Fixes: f6badf9eb582 ("batman-adv: Distributed ARP Table - implement local storage")
+Signed-off-by: Vladislav Efanov <VEfanov@ispras.ru>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/177ba85fb2d4ca2ecd30ca16803560e80e916fac
+
+--- a/net/batman-adv/distributed-arp-table.c
++++ b/net/batman-adv/distributed-arp-table.c
+@@ -101,7 +101,6 @@ static void batadv_dat_purge(struct work
+  */
+ static void batadv_dat_start_timer(struct batadv_priv *bat_priv)
+ {
+-	INIT_DELAYED_WORK(&bat_priv->dat.work, batadv_dat_purge);
+ 	queue_delayed_work(batadv_event_workqueue, &bat_priv->dat.work,
+ 			   msecs_to_jiffies(10000));
+ }
+@@ -819,6 +818,7 @@ int batadv_dat_init(struct batadv_priv *
+ 	if (!bat_priv->dat.hash)
+ 		return -ENOMEM;
+ 
++	INIT_DELAYED_WORK(&bat_priv->dat.work, batadv_dat_purge);
+ 	batadv_dat_start_timer(bat_priv);
+ 
+ 	batadv_tvlv_handler_register(bat_priv, batadv_dat_tvlv_ogm_handler_v1,

--- a/batman-adv/patches/0004-batman-adv-compat-Use-native-kstrtox.h-for-5.10.185.patch
+++ b/batman-adv/patches/0004-batman-adv-compat-Use-native-kstrtox.h-for-5.10.185.patch
@@ -1,0 +1,29 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Tue, 11 Jul 2023 11:46:30 +0200
+Subject: batman-adv: compat: Use native kstrtox.h for 5.10.185
+
+Upstream stable commit 6e2e551e39fd ("kernel.h: split out kstrtox() and
+simple_strtox() to a separate header") backported the support for
+linux/kstrtox.h. Unfortunately, the compat support via linux/kernel.h was
+dropped and thus references to kstrtou64 caused build errors
+
+  batman-adv/net/batman-adv/gateway_common.c: In function ‘batadv_parse_throughput’:
+  batman-adv/net/batman-adv/gateway_common.c:55:15: error: implicit declaration of function ‘kstrtou64’ [-Werror=implicit-function-declaration]
+     55 |         ret = kstrtou64(buff, 10, &lthroughput);
+        |               ^~~~~~~~~
+
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/8924adbdf993cd0521f9d0024b43e3b23af5114f
+
+--- a/compat-include/linux/kstrtox.h
++++ b/compat-include/linux/kstrtox.h
+@@ -11,7 +11,8 @@
+ #define _NET_BATMAN_ADV_COMPAT_LINUX_KSTRTOX_H_
+ 
+ #include <linux/version.h>
+-#if LINUX_VERSION_IS_GEQ(5, 14, 0)
++#if (LINUX_VERSION_IS_GEQ(5, 10, 185) && LINUX_VERSION_IS_LESS(5, 11, 0)) || \
++    LINUX_VERSION_IS_GEQ(5, 14, 0)
+ #include_next <linux/kstrtox.h>
+ #else
+ #include <linux/kernel.h>

--- a/batman-adv/patches/0005-batman-adv-Do-not-get-eth-header-before-batadv_check.patch
+++ b/batman-adv/patches/0005-batman-adv-Do-not-get-eth-header-before-batadv_check.patch
@@ -1,0 +1,111 @@
+From: Remi Pommarel <repk@triplefau.lt>
+Date: Fri, 28 Jul 2023 15:38:50 +0200
+Subject: batman-adv: Do not get eth header before batadv_check_management_packet
+
+If received skb in batadv_v_elp_packet_recv or batadv_v_ogm_packet_recv
+is either cloned or non linearized then its data buffer will be
+reallocated by batadv_check_management_packet when skb_cow or
+skb_linearize get called. Thus geting ethernet header address inside
+skb data buffer before batadv_check_management_packet had any chance to
+reallocate it could lead to the following kernel panic:
+
+  Unable to handle kernel paging request at virtual address ffffff8020ab069a
+  Mem abort info:
+    ESR = 0x96000007
+    EC = 0x25: DABT (current EL), IL = 32 bits
+    SET = 0, FnV = 0
+    EA = 0, S1PTW = 0
+    FSC = 0x07: level 3 translation fault
+  Data abort info:
+    ISV = 0, ISS = 0x00000007
+    CM = 0, WnR = 0
+  swapper pgtable: 4k pages, 39-bit VAs, pgdp=0000000040f45000
+  [ffffff8020ab069a] pgd=180000007fffa003, p4d=180000007fffa003, pud=180000007fffa003, pmd=180000007fefe003, pte=0068000020ab0706
+  Internal error: Oops: 96000007 [#1] SMP
+  Modules linked in: ahci_mvebu libahci_platform libahci dvb_usb_af9035 dvb_usb_dib0700 dib0070 dib7000m dibx000_common ath11k_pci ath10k_pci ath10k_core mwl8k_new nf_nat_sip nf_conntrack_sip xhci_plat_hcd xhci_hcd nf_nat_pptp nf_conntrack_pptp at24 sbsa_gwdt
+  CPU: 1 PID: 16 Comm: ksoftirqd/1 Not tainted 5.15.42-00066-g3242268d425c-dirty #550
+  Hardware name: A8k (DT)
+  pstate: 60000005 (nZCv daif -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
+  pc : batadv_is_my_mac+0x60/0xc0
+  lr : batadv_v_ogm_packet_recv+0x98/0x5d0
+  sp : ffffff8000183820
+  x29: ffffff8000183820 x28: 0000000000000001 x27: ffffff8014f9af00
+  x26: 0000000000000000 x25: 0000000000000543 x24: 0000000000000003
+  x23: ffffff8020ab0580 x22: 0000000000000110 x21: ffffff80168ae880
+  x20: 0000000000000000 x19: ffffff800b561000 x18: 0000000000000000
+  x17: 0000000000000000 x16: 0000000000000000 x15: 00dc098924ae0032
+  x14: 0f0405433e0054b0 x13: ffffffff00000080 x12: 0000004000000001
+  x11: 0000000000000000 x10: 0000000000000000 x9 : 0000000000000000
+  x8 : 0000000000000000 x7 : ffffffc076dae000 x6 : ffffff8000183700
+  x5 : ffffffc00955e698 x4 : ffffff80168ae000 x3 : ffffff80059cf000
+  x2 : ffffff800b561000 x1 : ffffff8020ab0696 x0 : ffffff80168ae880
+  Call trace:
+   batadv_is_my_mac+0x60/0xc0
+   batadv_v_ogm_packet_recv+0x98/0x5d0
+   batadv_batman_skb_recv+0x1b8/0x244
+   __netif_receive_skb_core.isra.0+0x440/0xc74
+   __netif_receive_skb_one_core+0x14/0x20
+   netif_receive_skb+0x68/0x140
+   br_pass_frame_up+0x70/0x80
+   br_handle_frame_finish+0x108/0x284
+   br_handle_frame+0x190/0x250
+   __netif_receive_skb_core.isra.0+0x240/0xc74
+   __netif_receive_skb_list_core+0x6c/0x90
+   netif_receive_skb_list_internal+0x1f4/0x310
+   napi_complete_done+0x64/0x1d0
+   gro_cell_poll+0x7c/0xa0
+   __napi_poll+0x34/0x174
+   net_rx_action+0xf8/0x2a0
+   _stext+0x12c/0x2ac
+   run_ksoftirqd+0x4c/0x7c
+   smpboot_thread_fn+0x120/0x210
+   kthread+0x140/0x150
+   ret_from_fork+0x10/0x20
+  Code: f9403844 eb03009f 54fffee1 f94
+
+Thus ethernet header address should only be fetched after
+batadv_check_management_packet has been called.
+
+Fixes: 632835348e65 ("batman-adv: OGMv2 - add basic infrastructure")
+Signed-off-by: Remi Pommarel <repk@triplefau.lt>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/670971ac7e9a47ee952848e0ea9128180e8fb991
+
+--- a/net/batman-adv/bat_v_elp.c
++++ b/net/batman-adv/bat_v_elp.c
+@@ -505,7 +505,7 @@ int batadv_v_elp_packet_recv(struct sk_b
+ 	struct batadv_priv *bat_priv = netdev_priv(if_incoming->soft_iface);
+ 	struct batadv_elp_packet *elp_packet;
+ 	struct batadv_hard_iface *primary_if;
+-	struct ethhdr *ethhdr = (struct ethhdr *)skb_mac_header(skb);
++	struct ethhdr *ethhdr;
+ 	bool res;
+ 	int ret = NET_RX_DROP;
+ 
+@@ -513,6 +513,7 @@ int batadv_v_elp_packet_recv(struct sk_b
+ 	if (!res)
+ 		goto free_skb;
+ 
++	ethhdr = eth_hdr(skb);
+ 	if (batadv_is_my_mac(bat_priv, ethhdr->h_source))
+ 		goto free_skb;
+ 
+--- a/net/batman-adv/bat_v_ogm.c
++++ b/net/batman-adv/bat_v_ogm.c
+@@ -985,7 +985,7 @@ int batadv_v_ogm_packet_recv(struct sk_b
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(if_incoming->soft_iface);
+ 	struct batadv_ogm2_packet *ogm_packet;
+-	struct ethhdr *ethhdr = eth_hdr(skb);
++	struct ethhdr *ethhdr;
+ 	int ogm_offset;
+ 	u8 *packet_pos;
+ 	int ret = NET_RX_DROP;
+@@ -999,6 +999,7 @@ int batadv_v_ogm_packet_recv(struct sk_b
+ 	if (!batadv_check_management_packet(skb, if_incoming, BATADV_OGM2_HLEN))
+ 		goto free_skb;
+ 
++	ethhdr = eth_hdr(skb);
+ 	if (batadv_is_my_mac(bat_priv, ethhdr->h_source))
+ 		goto free_skb;
+ 

--- a/batman-adv/patches/0006-batman-adv-Trigger-events-for-auto-adjusted-MTU.patch
+++ b/batman-adv/patches/0006-batman-adv-Trigger-events-for-auto-adjusted-MTU.patch
@@ -1,0 +1,28 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Wed, 19 Jul 2023 10:15:05 +0200
+Subject: batman-adv: Trigger events for auto adjusted MTU
+
+If an interface changes the MTU, it is expected that an NETDEV_PRECHANGEMTU
+and NETDEV_CHANGEMTU notification events is triggered. This worked fine for
+.ndo_change_mtu based changes because core networking code took care of it.
+But for auto-adjustments after hard-interfaces changes, these events were
+simply missing.
+
+Due to this problem, non-batman-adv components weren't aware of MTU changes
+and thus couldn't perform their own tasks correctly.
+
+Fixes: 8009e9f7ac4f ("set bat0 MTU according to the MTUs of the hard interfaces")
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/27c4d7c1c7fa39d71ea6ccf1c23bcb4773243800
+
+--- a/net/batman-adv/hard-interface.c
++++ b/net/batman-adv/hard-interface.c
+@@ -629,7 +629,7 @@ out:
+  */
+ void batadv_update_min_mtu(struct net_device *soft_iface)
+ {
+-	soft_iface->mtu = batadv_hardif_min_mtu(soft_iface);
++	dev_set_mtu(soft_iface, batadv_hardif_min_mtu(soft_iface));
+ 
+ 	/* Check if the local translate table should be cleaned up to match a
+ 	 * new (and smaller) MTU.

--- a/batman-adv/patches/0007-batman-adv-Don-t-increase-MTU-when-set-by-user.patch
+++ b/batman-adv/patches/0007-batman-adv-Don-t-increase-MTU-when-set-by-user.patch
@@ -1,0 +1,71 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Wed, 19 Jul 2023 10:15:06 +0200
+Subject: batman-adv: Don't increase MTU when set by user
+
+If the user set an MTU value, it usually means that there are special
+requirements for the MTU. But if an interface gots activated, the MTU was
+always recalculated and then the user set value was overwritten.
+
+The only reason why this user set value has to be overwritten, is when the
+MTU has to be decreased because batman-adv is not able to transfer packets
+with the user specified size.
+
+Fixes: 88861ea9acb7 ("[batman-adv] replacing if up/down timer with kernel notifications")
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/2745af592150b758ee96abf9329dd5f42cf22c25
+
+--- a/net/batman-adv/hard-interface.c
++++ b/net/batman-adv/hard-interface.c
+@@ -629,7 +629,19 @@ out:
+  */
+ void batadv_update_min_mtu(struct net_device *soft_iface)
+ {
+-	dev_set_mtu(soft_iface, batadv_hardif_min_mtu(soft_iface));
++	struct batadv_priv *bat_priv = netdev_priv(soft_iface);
++	int limit_mtu;
++	int mtu;
++
++	mtu = batadv_hardif_min_mtu(soft_iface);
++
++	if (bat_priv->mtu_set_by_user)
++		limit_mtu = bat_priv->mtu_set_by_user;
++	else
++		limit_mtu = ETH_DATA_LEN;
++
++	mtu = min(mtu, limit_mtu);
++	dev_set_mtu(soft_iface, mtu);
+ 
+ 	/* Check if the local translate table should be cleaned up to match a
+ 	 * new (and smaller) MTU.
+--- a/net/batman-adv/soft-interface.c
++++ b/net/batman-adv/soft-interface.c
+@@ -153,11 +153,14 @@ static int batadv_interface_set_mac_addr
+ 
+ static int batadv_interface_change_mtu(struct net_device *dev, int new_mtu)
+ {
++	struct batadv_priv *bat_priv = netdev_priv(dev);
++
+ 	/* check ranges */
+ 	if (new_mtu < 68 || new_mtu > batadv_hardif_min_mtu(dev))
+ 		return -EINVAL;
+ 
+ 	dev->mtu = new_mtu;
++	bat_priv->mtu_set_by_user = new_mtu;
+ 
+ 	return 0;
+ }
+--- a/net/batman-adv/types.h
++++ b/net/batman-adv/types.h
+@@ -1547,6 +1547,12 @@ struct batadv_priv {
+ 	struct net_device *soft_iface;
+ 
+ 	/**
++	 * @mtu_set_by_user: MTU was set once by user
++	 * protected by rtnl_lock
++	 */
++	int mtu_set_by_user;
++
++	/**
+ 	 * @bat_counters: mesh internal traffic statistic counters (see
+ 	 *  batadv_counters)
+ 	 */

--- a/batman-adv/patches/0008-batman-adv-Fix-TT-global-entry-leak-when-client-roam.patch
+++ b/batman-adv/patches/0008-batman-adv-Fix-TT-global-entry-leak-when-client-roam.patch
@@ -1,0 +1,76 @@
+From: Remi Pommarel <repk@triplefau.lt>
+Date: Fri, 4 Aug 2023 11:39:36 +0200
+Subject: batman-adv: Fix TT global entry leak when client roamed back
+
+When a client roamed back to a node before it got time to destroy the
+pending local entry (i.e. within the same originator interval) the old
+global one is directly removed from hash table and left as such.
+
+But because this entry had an extra reference taken at lookup (i.e using
+batadv_tt_global_hash_find) there is no way its memory will be reclaimed
+at any time causing the following memory leak:
+
+  unreferenced object 0xffff0000073c8000 (size 18560):
+    comm "softirq", pid 0, jiffies 4294907738 (age 228.644s)
+    hex dump (first 32 bytes):
+      06 31 ac 12 c7 7a 05 00 01 00 00 00 00 00 00 00  .1...z..........
+      2c ad be 08 00 80 ff ff 6c b6 be 08 00 80 ff ff  ,.......l.......
+    backtrace:
+      [<00000000ee6e0ffa>] kmem_cache_alloc+0x1b4/0x300
+      [<000000000ff2fdbc>] batadv_tt_global_add+0x700/0xe20
+      [<00000000443897c7>] _batadv_tt_update_changes+0x21c/0x790
+      [<000000005dd90463>] batadv_tt_update_changes+0x3c/0x110
+      [<00000000a2d7fc57>] batadv_tt_tvlv_unicast_handler_v1+0xafc/0xe10
+      [<0000000011793f2a>] batadv_tvlv_containers_process+0x168/0x2b0
+      [<00000000b7cbe2ef>] batadv_recv_unicast_tvlv+0xec/0x1f4
+      [<0000000042aef1d8>] batadv_batman_skb_recv+0x25c/0x3a0
+      [<00000000bbd8b0a2>] __netif_receive_skb_core.isra.0+0x7a8/0xe90
+      [<000000004033d428>] __netif_receive_skb_one_core+0x64/0x74
+      [<000000000f39a009>] __netif_receive_skb+0x48/0xe0
+      [<00000000f2cd8888>] process_backlog+0x174/0x344
+      [<00000000507d6564>] __napi_poll+0x58/0x1f4
+      [<00000000b64ef9eb>] net_rx_action+0x504/0x590
+      [<00000000056fa5e4>] _stext+0x1b8/0x418
+      [<00000000878879d6>] run_ksoftirqd+0x74/0xa4
+  unreferenced object 0xffff00000bae1a80 (size 56):
+    comm "softirq", pid 0, jiffies 4294910888 (age 216.092s)
+    hex dump (first 32 bytes):
+      00 78 b1 0b 00 00 ff ff 0d 50 00 00 00 00 00 00  .x.......P......
+      00 00 00 00 00 00 00 00 50 c8 3c 07 00 00 ff ff  ........P.<.....
+    backtrace:
+      [<00000000ee6e0ffa>] kmem_cache_alloc+0x1b4/0x300
+      [<00000000d9aaa49e>] batadv_tt_global_add+0x53c/0xe20
+      [<00000000443897c7>] _batadv_tt_update_changes+0x21c/0x790
+      [<000000005dd90463>] batadv_tt_update_changes+0x3c/0x110
+      [<00000000a2d7fc57>] batadv_tt_tvlv_unicast_handler_v1+0xafc/0xe10
+      [<0000000011793f2a>] batadv_tvlv_containers_process+0x168/0x2b0
+      [<00000000b7cbe2ef>] batadv_recv_unicast_tvlv+0xec/0x1f4
+      [<0000000042aef1d8>] batadv_batman_skb_recv+0x25c/0x3a0
+      [<00000000bbd8b0a2>] __netif_receive_skb_core.isra.0+0x7a8/0xe90
+      [<000000004033d428>] __netif_receive_skb_one_core+0x64/0x74
+      [<000000000f39a009>] __netif_receive_skb+0x48/0xe0
+      [<00000000f2cd8888>] process_backlog+0x174/0x344
+      [<00000000507d6564>] __napi_poll+0x58/0x1f4
+      [<00000000b64ef9eb>] net_rx_action+0x504/0x590
+      [<00000000056fa5e4>] _stext+0x1b8/0x418
+      [<00000000878879d6>] run_ksoftirqd+0x74/0xa4
+
+Releasing the extra reference from batadv_tt_global_hash_find even at
+roam back when batadv_tt_global_free is called fixes this memory leak.
+
+Cc: stable@vger.kernel.org
+Fixes: 2443ba383c7d ("batman-adv: roaming handling mechanism redesign")
+Signed-off-by: Remi Pommarel <repk@triplefau.lt>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/26fce59c70729e07034de966ac5fd2d5c1f2d597
+
+--- a/net/batman-adv/translation-table.c
++++ b/net/batman-adv/translation-table.c
+@@ -774,7 +774,6 @@ check_roaming:
+ 		if (roamed_back) {
+ 			batadv_tt_global_free(bat_priv, tt_global,
+ 					      "Roaming canceled");
+-			tt_global = NULL;
+ 		} else {
+ 			/* The global entry has to be marked as ROAMING and
+ 			 * has to be kept for consistency purpose

--- a/batman-adv/patches/0009-batman-adv-Fix-batadv_v_ogm_aggr_send-memory-leak.patch
+++ b/batman-adv/patches/0009-batman-adv-Fix-batadv_v_ogm_aggr_send-memory-leak.patch
@@ -1,0 +1,47 @@
+From: Remi Pommarel <repk@triplefau.lt>
+Date: Wed, 9 Aug 2023 17:29:13 +0200
+Subject: batman-adv: Fix batadv_v_ogm_aggr_send memory leak
+
+When batadv_v_ogm_aggr_send is called for an inactive interface, the skb
+is silently dropped by batadv_v_ogm_send_to_if() but never freed causing
+the following memory leak:
+
+  unreferenced object 0xffff00000c164800 (size 512):
+    comm "kworker/u8:1", pid 2648, jiffies 4295122303 (age 97.656s)
+    hex dump (first 32 bytes):
+      00 80 af 09 00 00 ff ff e1 09 00 00 75 01 60 83  ............u.`.
+      1f 00 00 00 b8 00 00 00 15 00 05 00 da e3 d3 64  ...............d
+    backtrace:
+      [<0000000007ad20f6>] __kmalloc_track_caller+0x1a8/0x310
+      [<00000000d1029e55>] kmalloc_reserve.constprop.0+0x70/0x13c
+      [<000000008b9d4183>] __alloc_skb+0xec/0x1fc
+      [<00000000c7af5051>] __netdev_alloc_skb+0x48/0x23c
+      [<00000000642ee5f5>] batadv_v_ogm_aggr_send+0x50/0x36c
+      [<0000000088660bd7>] batadv_v_ogm_aggr_work+0x24/0x40
+      [<0000000042fc2606>] process_one_work+0x3b0/0x610
+      [<000000002f2a0b1c>] worker_thread+0xa0/0x690
+      [<0000000059fae5d4>] kthread+0x1fc/0x210
+      [<000000000c587d3a>] ret_from_fork+0x10/0x20
+
+Free the skb in that case to fix this leak.
+
+Cc: stable@vger.kernel.org
+Fixes: 632835348e65 ("batman-adv: OGMv2 - add basic infrastructure")
+Signed-off-by: Remi Pommarel <repk@triplefau.lt>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/9024db261180f73fc687a9ecc7e79e3b0ccf50dc
+
+--- a/net/batman-adv/bat_v_ogm.c
++++ b/net/batman-adv/bat_v_ogm.c
+@@ -123,8 +123,10 @@ static void batadv_v_ogm_send_to_if(stru
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(hard_iface->soft_iface);
+ 
+-	if (hard_iface->if_status != BATADV_IF_ACTIVE)
++	if (hard_iface->if_status != BATADV_IF_ACTIVE) {
++		kfree_skb(skb);
+ 		return;
++	}
+ 
+ 	batadv_inc_counter(bat_priv, BATADV_CNT_MGMT_TX);
+ 	batadv_add_counter(bat_priv, BATADV_CNT_MGMT_TX_BYTES,


### PR DESCRIPTION
Maintainer: @simonwunderlich
Compile tested: ramips mt7621
Run tested: ramips mt7621 TP-Link EAP615-Wall v1

batman-adv
==========

* Broken sync while rescheduling delayed work
* compat: Use native kstrtox.h for 5.10.185
* Do not get eth header before batadv_check_management_packet
* Trigger events for auto adjusted MTU
* Don't increase MTU when set by user
* Fix TT global entry leak when client roamed back
* Fix batadv_v_ogm_aggr_send memory leak