### PR TITLE
bird2: bump to version 2.14

### DIFF
--- a/bird2/Makefile
+++ b/bird2/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird2
-PKG_VERSION:=2.13.1
+PKG_VERSION:=2.14
 PKG_RELEASE:=1
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://bird.network.cz/pub/bird
-PKG_HASH:=97bb8d57be9bc5083e2b566416d27e314162856a12ca7c77e202e467d20d4080
+PKG_HASH:=b0b9f6f8566541b9be4af1f0cac675c5a3785601a55667a7ec3d7de29735a786
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Maintainer: @tohojo 
Compile tested: (x86-64, OpenWrt 23.05.0-rc4)
Run tested: (x86-64, OpenWrt 23.05.0-rc4, tests done)

Description:
