### PR TITLE
[23.05] opennds: update to version 10.2.0

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
-PKG_VERSION:=10.1.3
+PKG_VERSION:=10.2.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=8016a8d20643a2dfc7e8d9e8012e300db6996aeede5ea8a895cb1b95e52f202a
+PKG_HASH:=c2da51e3051e390fc1ddae2a4fa751f7b62919eb8e5526710067ca4622331017
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>
@@ -72,6 +72,7 @@ define Package/opennds/install
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/post-request.php $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-aes/fas-aes.php $(1)/etc/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-hid/fas-hid.php $(1)/etc/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-hid/fas-hid-https.php $(1)/etc/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-aes/fas-aes-https.php $(1)/etc/opennds/
 endef
 


### PR DESCRIPTION
Maintainer: Rob White rob@blue-wave.net

Compile tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, x86-64

Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, x86-64; on snapshot, 23.05, 22.03

Description:
opennds (10.2.0) - This version is a minor upgrade that introduces some significant additional functionality. In addition it includes numerous enhancements bug fixes and cosmetic fixes.

Additional functionality includes:

 * Pre-emptive Client Lists
 * Autonomous Block Lists
 * Internet hosted https FAS support for resource limited routers
 * Fair Usage Policy

Details can be found here:
https://github.com/openNDS/openNDS/releases/tag/v10.2.0

Signed-off-by: Rob White <rob@blue-wave.net>
(cherry picked from commit a5ec54aee3df6aa400e454ef0468127dcd0c6b25)
