### PR TITLE
batman-adv: fix 2023.3 compilation issue

### DIFF
--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
 PKG_VERSION:=2023.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)

--- a/batman-adv/src/compat-hacks.h
+++ b/batman-adv/src/compat-hacks.h
@@ -28,20 +28,6 @@ static inline u32 batadv_get_random_u32_below(u32 ep_ro)
 
 #endif /* LINUX_VERSION_IS_LESS(6, 2, 0) */
 
-#if LINUX_VERSION_IS_LESS(6, 4, 0)
-
-#include <linux/if_vlan.h>
-
-/* Prefer this version in TX path, instead of
- * skb_reset_mac_header() + vlan_eth_hdr()
- */
-static inline struct vlan_ethhdr *skb_vlan_eth_hdr(const struct sk_buff *skb)
-{
-	return (struct vlan_ethhdr *)skb->data;
-}
-
-#endif /* LINUX_VERSION_IS_LESS(6, 4, 0) */
-
 /* <DECLARE_EWMA> */
 
 #include <linux/version.h>


### PR DESCRIPTION
Maintainer: @ecsv @simonwunderlich 
Compile tested: `mediatek/fiilogic` Sinovoip Banana Pi R3, snapshot kernel 6.1.69
Compile tested: `ramipsmt7621` D-Link DAP-1620 B1, snapshot kernel 5.15.144
Run tested: `ramipsmt7621` D-Link DAP-1620 B1, snapshot kernel 5.15.144

Description:
Compilation failed due to redefinition of `skb_vlan_eth_hdr`;
Removed the relevant lines from `compat-hacks.h` and now it's fine.

Fixes: 28b8a5eafe6e05b
Closes: #1036
