### PR TITLE
batman-adv: compat: Fix skb_vlan_eth_hdr conflict in stable kernels

### DIFF
--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
 PKG_VERSION:=2023.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)

--- a/batman-adv/src/compat-hacks.h
+++ b/batman-adv/src/compat-hacks.h
@@ -28,7 +28,10 @@ static inline u32 batadv_get_random_u32_below(u32 ep_ro)
 
 #endif /* LINUX_VERSION_IS_LESS(6, 2, 0) */
 
-#if LINUX_VERSION_IS_LESS(6, 4, 0)
+#if LINUX_VERSION_IS_LESS(6, 4, 0) && \
+    !(LINUX_VERSION_IS_GEQ(5, 10, 205) && LINUX_VERSION_IS_LESS(5, 11, 0)) && \
+    !(LINUX_VERSION_IS_GEQ(5, 15, 144) && LINUX_VERSION_IS_LESS(5, 16, 0)) && \
+    !(LINUX_VERSION_IS_GEQ(6, 1, 69) && LINUX_VERSION_IS_LESS(6, 2, 0))
 
 #include <linux/if_vlan.h>
 


### PR DESCRIPTION
Maintainer:  @simonwunderlich 
Compile tested: ramips / mipsel_24kc (mt76x8)
Run tested: -

Description:

The newest Linux stable kernel releases:

* v5.10.205
* v5.15.144
* v6.1.69

received a backported version of commit 1f5020acb33f ("net: vlan: introduce skb_vlan_eth_hdr()"). batman-adv must therefore not provide this function any longer for these kernel versions.

Closes: #1036