### PR TITLE
batman-adv: Provide teardown hook for batadv_vlan proto

### DIFF
--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
 PKG_VERSION:=2024.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)

--- a/batman-adv/files/lib/netifd/proto/batadv_vlan.sh
+++ b/batman-adv/files/lib/netifd/proto/batadv_vlan.sh
@@ -22,4 +22,8 @@ proto_batadv_vlan_setup() {
 	proto_send_update "$config"
 }
 
+proto_batadv_vlan_teardown() {
+	local cfg="$1"
+}
+
 add_protocol batadv_vlan


### PR DESCRIPTION
Maintainer: @simonwunderlich 
Compile tested: ath79, GL.iNet GL-AR750
Run tested: ath79, GL.iNet GL-AR750

Description:

The batadv_vlan proto doesn't need to do anything when it gets teared down. But the scripts are still trying to call the teardown function of this proto. This results in warnings like:

    daemon.notice netifd: batmesh1 (18940): ./batadv_vlan.sh: eval: line 37: proto_batadv_vlan_teardown: not found

Just providing a stub function avoids this log spam.

Fixes: #1044
Reported-by: Rani Hod <rani.hod@gmail.com>
Fixes: f5205d7d2434 ("batman-adv: upgrade package to latest release 2014.2.0")

