### PR TITLE
[23.05] opennds: update to version 10.3.0

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
-PKG_VERSION:=10.2.0
+PKG_VERSION:=10.3.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=c2da51e3051e390fc1ddae2a4fa751f7b62919eb8e5526710067ca4622331017
+PKG_HASH:=5ac2ec7e4c5b860db4081895b07864bb4bf686205f0dcc3cdbd83f89e160fed8
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>


### PR DESCRIPTION
Maintainer: Rob White rob@blue-wave.net

Compile tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, aarch64_cortex-a53, x86-64

Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, mips_24kc, aarch64_cortex-a53, x86-64 ;
    On 23.5 and master/snapshot.

Description:
opennds (10.3.0) - This version is a minor upgrade that introduces some significant additional functionality. In addition it includes numerous enhancements bug fixes and cosmetic fixes.

Additional functionality includes:

 1. Support for integration of Mesh11sd meshnodes
 2. Download protocol debugging
 3. Resolving of fqdn ip addresses on CDN systems with multiple ip addresses
 4. Support for specifying alternate dhcp leases file location

Details can be found here:
https://github.com/openNDS/openNDS/releases/tag/v10.3.0

Signed-off-by: Rob White <rob@blue-wave.net>
(cherry picked from commit 4ac486b2d5ef4c965e6233bafb5709fd2a8d25de)
