### PR TITLE
batman-adv: update packages to version 2024.2

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alfred
-PKG_VERSION:=2024.1
+PKG_VERSION:=2024.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=262dad39c9be122ac7f061705c8a3e3b6d462782bbe3372e6dfc9ace0c384db9
+PKG_HASH:=a8404c6617ee9b5a4e605b516bc694afc6596130bc802bfd30fbc7a1db3aef1f
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
 PKG_LICENSE:=GPL-2.0-only MIT

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
-PKG_VERSION:=2024.1
+PKG_VERSION:=2024.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=683dda9d6054eb260a1ac0022c642798ff4048d6c53a672ea0b3178e6b757a09
+PKG_HASH:=cb02953093ffc2c700d122c03a3d9e4d867f646d3038f31d0a901e58ff995d07
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
-PKG_VERSION:=2024.1
+PKG_VERSION:=2024.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=a714329c6251f4830e9cf03f53cbfb2280f0678471b54c5d46fae61a782d4325
+PKG_HASH:=7692a6dee7a2f3f66732e9aec8c7164e0c1818167f3af063bff3fffbb0199643
 PKG_EXTMOD_SUBDIRS:=net/batman-adv
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/patches/0003-Revert-batman-adv-Switch-to-linux-sprintf.h.patch
+++ b/batman-adv/patches/0003-Revert-batman-adv-Switch-to-linux-sprintf.h.patch
@@ -69,7 +69,7 @@ This reverts commit f0fb49c5ab70dfa064f0aa8d1c5d84f65e8cbc86.
  #include <net/sock.h>
 --- a/net/batman-adv/main.c
 +++ b/net/batman-adv/main.c
-@@ -32,7 +32,6 @@
+@@ -31,7 +31,6 @@
  #include <linux/skbuff.h>
  #include <linux/slab.h>
  #include <linux/spinlock.h>

--- a/batman-adv/patches/0004-Revert-batman-adv-Switch-to-linux-array_size.h.patch
+++ b/batman-adv/patches/0004-Revert-batman-adv-Switch-to-linux-array_size.h.patch
@@ -41,7 +41,7 @@ This reverts commit f33d7f724675544a36b24c77f8d4b95d41252ae2.
  #include <linux/atomic.h>
  #include <linux/build_bug.h>
  #include <linux/byteorder/generic.h>
-@@ -20,6 +19,7 @@
+@@ -19,6 +18,7 @@
  #include <linux/init.h>
  #include <linux/ip.h>
  #include <linux/ipv6.h>
@@ -59,7 +59,7 @@ This reverts commit f33d7f724675544a36b24c77f8d4b95d41252ae2.
  #include <linux/atomic.h>
  #include <linux/bitops.h>
  #include <linux/bug.h>
-@@ -20,6 +19,7 @@
+@@ -19,6 +18,7 @@
  #include <linux/if_ether.h>
  #include <linux/if_vlan.h>
  #include <linux/init.h>


### PR DESCRIPTION
Maintainer: @simonwunderlich 
Compile tested: x86_64
Run tested: x86_64

Description:

batman-adv
==========

* support latest kernels (4.19 - 6.10)
* coding style cleanups and refactoring