### PR TITLE
openwrt-23.05: batman-adv: Import bugfixes from 2024.3 release

### DIFF
--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
 PKG_VERSION:=2023.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)

--- a/batctl/patches/0007-batctl-Dynamically-select-header-format-in-netlink_p.patch
+++ b/batctl/patches/0007-batctl-Dynamically-select-header-format-in-netlink_p.patch
@@ -1,0 +1,55 @@
+From: Noah Peterson <NoahBPeterson1997@gmail.com>
+Date: Tue, 10 Sep 2024 13:22:02 -0600
+Subject: batctl: Dynamically select header format in netlink_print_neighbors
+
+The netlink_print_neighbors() function previously used a static header
+format, which did not account for variations between the neighbor list
+output from different BATMAN routing algorithms (BATMAN_IV vs. BATMAN_V).
+
+This change ensures that the table header output in `batctl n` is accurate
+for both BATMAN routing algorithms.
+
+Signed-off-by: Noah Peterson <noahbpeterson1997@gmail.com>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batctl.git/commit/649456d9d00cf701eb35cee1c8c5442752c70613
+
+--- a/neighbors.c
++++ b/neighbors.c
+@@ -6,6 +6,7 @@
+  * License-Filename: LICENSES/preferred/GPL-2.0
+  */
+ 
++#include <errno.h>
+ #include <net/if.h>
+ #include <netinet/if_ether.h>
+ #include <netlink/netlink.h>
+@@ -119,9 +120,28 @@ static int netlink_print_neighbors(struc
+ 				   int read_opts, float orig_timeout,
+ 				   float watch_interval)
+ {
++	char *header = NULL;
++	char *info_header;
++
++	/* only parse routing algorithm name */
++	last_err = -EINVAL;
++	info_header = netlink_get_info(state, BATADV_CMD_GET_ORIGINATORS, NULL);
++	free(info_header);
++
++	if (strlen(algo_name_buf) == 0)
++		return last_err;
++
++	if (!strcmp("BATMAN_IV", algo_name_buf))
++		header = "IF             Neighbor              last-seen\n";
++	if (!strcmp("BATMAN_V", algo_name_buf))
++		header = "         Neighbor   last-seen      speed           IF\n";
++
++	if (!header)
++		return -EINVAL;
++
+ 	return netlink_print_common(state, orig_iface, read_opts,
+ 				    orig_timeout, watch_interval,
+-				    "IF             Neighbor              last-seen\n",
++				    header,
+ 				    BATADV_CMD_GET_NEIGHBORS,
+ 				    neighbors_callback);
+ }

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
 PKG_VERSION:=2023.1
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)

--- a/batman-adv/patches/0012-batman-adv-Don-t-accept-TT-entries-for-out-of-spec-V.patch
+++ b/batman-adv/patches/0012-batman-adv-Don-t-accept-TT-entries-for-out-of-spec-V.patch
@@ -1,0 +1,79 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Sat, 4 May 2024 22:27:21 +0200
+Subject: batman-adv: Don't accept TT entries for out-of-spec VIDs
+
+The internal handling of VLAN IDs in batman-adv is only specified for
+following encodings:
+
+* VLAN is used
+  - bit 15 is 1
+  - bit 11 - bit 0 is the VLAN ID (0-4095)
+  - remaining bits are 0
+* No VLAN is used
+  - bit 15 is 0
+  - remaining bits are 0
+
+batman-adv was only preparing new translation table entries (based on its
+soft interface information) using this encoding format. But the receive
+path was never checking if entries in the roam or TT TVLVs were also
+following this encoding.
+
+It was therefore possible to create more than the expected maximum of 4096
++ 1 entries in the originator VLAN list. Simply by setting the "remaining
+bits" to "random" values in corresponding TVLV.
+
+Fixes: 21a57f6e7a3b ("batman-adv: make the TT CRC logic VLAN specific")
+Reported-by: Linus Lüssing <linus.luessing@c0d3.blue>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/aa68ccb56023394b08929718645760dcc501f2d9
+
+--- a/net/batman-adv/originator.c
++++ b/net/batman-adv/originator.c
+@@ -11,6 +11,7 @@
+ #include <linux/errno.h>
+ #include <linux/etherdevice.h>
+ #include <linux/gfp.h>
++#include <linux/if_vlan.h>
+ #include <linux/jiffies.h>
+ #include <linux/kernel.h>
+ #include <linux/kref.h>
+@@ -132,6 +133,29 @@ batadv_orig_node_vlan_get(struct batadv_
+ }
+ 
+ /**
++ * batadv_vlan_id_valid() - check if vlan id is in valid batman-adv encoding
++ * @vid: the VLAN identifier
++ *
++ * Return: true when either no vlan is set or if VLAN is in correct range,
++ *  false otherwise
++ */
++static bool batadv_vlan_id_valid(unsigned short vid)
++{
++	unsigned short non_vlan = vid & ~(BATADV_VLAN_HAS_TAG | VLAN_VID_MASK);
++
++	if (vid == 0)
++		return true;
++
++	if (!(vid & BATADV_VLAN_HAS_TAG))
++		return false;
++
++	if (non_vlan)
++		return false;
++
++	return true;
++}
++
++/**
+  * batadv_orig_node_vlan_new() - search and possibly create an orig_node_vlan
+  *  object
+  * @orig_node: the originator serving the VLAN
+@@ -149,6 +173,9 @@ batadv_orig_node_vlan_new(struct batadv_
+ {
+ 	struct batadv_orig_node_vlan *vlan;
+ 
++	if (!batadv_vlan_id_valid(vid))
++		return NULL;
++
+ 	spin_lock_bh(&orig_node->vlan_list_lock);
+ 
+ 	/* first look if an object for this vid already exists */


### PR DESCRIPTION
Maintainer: @simonwunderlich 
Compile tested: x86_64
Run tested: x86_64

Description:

batman-adv
==========

* Don't accept TT entries for out-of-spec VIDs

batctl
======

* Dynamically select header format in netlink_print_neighbors