### PR TITLE
ndppd: bump to 0.2.5.43

### DIFF
--- a/ndppd/Makefile
+++ b/ndppd/Makefile
@@ -8,17 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ndppd
-PKG_VERSION:=0.2.5
-PKG_RELEASE:=2
+PKG_VERSION:=0.2.5.43
+PKG_RELEASE:=1
 
 # Latest release
-PKG_SOURCE_URL:=https://codeload.github.com/DanielAdolfsson/ndppd/tar.gz/$(PKG_VERSION)?
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=ee934167f8357f0bd0015e201a77fbe4d028c59e89dc98113805c6855e1c3992
+PKG_SOURCE_URL:=https://api.opensuse.org/public/source/network/ndppd/
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_HASH:=2a153959e7d56967c733adb36379bb56bc8b78df60daef2f0aacaa9153398d1b
 PKG_LICENSE:=GPL-3.0-or-later
 
 # Development snapshot
-#PKG_SOURCE_URL=git://github.com/Tuhox/ndppd.git
+#PKG_SOURCE_URL=git://github.com/DanielAdolfsson/ndppd.git
 #PKG_SOURCE_VERSION=master
 #PKG_SOURCE_SUBDIR=$(PKG_NAME)-$(PKG_VERSION)
 

--- a/ndppd/patches/0001-Version-bump.patch
+++ b/ndppd/patches/0001-Version-bump.patch
@@ -7,8 +7,6 @@ Subject: [PATCH 1/3] Forgot to bump the version.
  src/ndppd.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/src/ndppd.h b/src/ndppd.h
-index 57ba829..3e11221 100644
 --- a/src/ndppd.h
 +++ b/src/ndppd.h
 @@ -21,7 +21,7 @@
@@ -16,7 +14,7 @@ index 57ba829..3e11221 100644
  #define NDPPD_NS_END     }
  
 -#define NDPPD_VERSION   "0.2.4"
-+#define NDPPD_VERSION   "0.2.5"
++#define NDPPD_VERSION   "0.2.5.43"
  
  #include <assert.h>
  

--- a/ndppd/patches/0002-Fixes-strerror_r-GNU-XSI.patch
+++ b/ndppd/patches/0002-Fixes-strerror_r-GNU-XSI.patch
@@ -9,22 +9,21 @@ Subject: [PATCH 2/3] Fixes strerror_r GNU/XSI issue #40.
  src/logger.h  |  3 +++
  2 files changed, 15 insertions(+), 1 deletions(-)
 
-diff --git a/src/logger.cc b/src/logger.cc
-index 6ddbea9..6ccb2a0 100644
 --- a/src/logger.cc
 +++ b/src/logger.cc
-@@ -84,6 +84,6 @@ std::string logger::err()
- {
-     char buf[2048];
+@@ -89,7 +89,7 @@ std::string logger::err()
+         return "Unknown error";
+     return buf;
+ #else
 -    return strerror_r(errno, buf, sizeof(buf));
 +    return strerror_r_wrapper(strerror_r(errno, buf, sizeof(buf)), buf);
+ #endif
  }
  
- logger logger::error()
-@@ -221,4 +221,16 @@ 
+@@ -228,4 +228,16 @@ bool logger::verbosity(const std::string
      return false;
  }
-
+ 
 +// XSI-compliant: int
 +std::string logger::strerror_r_wrapper(int, char* s)
 +{
@@ -38,11 +37,9 @@ index 6ddbea9..6ccb2a0 100644
 +}
 +
  NDPPD_NS_END
-diff --git a/src/logger.h b/src/logger.h
-index 7d3d7db..0446595 100644
 --- a/src/logger.h
 +++ b/src/logger.h
-@@ -91,6 +91,9 @@ class logger {
+@@ -91,6 +91,9 @@ private:
  
      static int _max_pri;
  
@@ -52,4 +49,3 @@ index 7d3d7db..0446595 100644
  
  };
  
-

--- a/ndppd/patches/0003-fix-poll-header.patch
+++ b/ndppd/patches/0003-fix-poll-header.patch
@@ -11,8 +11,6 @@ Subject: [PATCH 3/3] Fixes a compile warning when building with musl: #warning
  src/rule.h   | 2 +-
  4 files changed, 4 insertions(+), 4 deletions(-)
 
-diff --git a/src/iface.cc b/src/iface.cc
-index f569d3c..7cbb57f 100644
 --- a/src/iface.cc
 +++ b/src/iface.cc
 @@ -30,7 +30,7 @@
@@ -24,8 +22,6 @@ index f569d3c..7cbb57f 100644
  
  #include <linux/filter.h>
  
-diff --git a/src/iface.h b/src/iface.h
-index 9db59ab..df7ff35 100644
 --- a/src/iface.h
 +++ b/src/iface.h
 @@ -20,7 +20,7 @@
@@ -37,8 +33,6 @@ index 9db59ab..df7ff35 100644
  #include <net/ethernet.h>
  
  #include "ndppd.h"
-diff --git a/src/proxy.h b/src/proxy.h
-index 8141b2a..9299d9a 100644
 --- a/src/proxy.h
 +++ b/src/proxy.h
 @@ -19,7 +19,7 @@
@@ -50,15 +44,14 @@ index 8141b2a..9299d9a 100644
  
  #include "ndppd.h"
  
-diff --git a/src/rule.h b/src/rule.h
-index 0c2f79a..23086e6 100644
 --- a/src/rule.h
 +++ b/src/rule.h
-@@ -20,6 +20,6 @@
+@@ -20,7 +20,7 @@
  #include <map>
+ #include <list>
  
 -#include <sys/poll.h>
 +#include <poll.h>
  
  #include "ndppd.h"
-
+ 


### PR DESCRIPTION
Maintainer: @mwarning
Compile tested: x86-64, generic, snapshot
Run tested: x86-64, generic, snapshot

Description:
ndppd 0.2.5 is too old and lacks many features.
ndppd 0.2.5.43 means commit eb81b8f, 43 commits after 0.2.5.
https://github.com/DanielAdolfsson/ndppd/compare/0.2.5...eb81b8f

This is what SUSE has done for SLE (SUSE Linux Enterprise), and this version has been tested for many years, so stability should not be a problem.
https://packagehub.suse.com/packages/ndppd/
https://build.opensuse.org/package/show/network/ndppd
https://src.opensuse.org/pool/ndppd