### PR TITLE
olsrd: fix APK package build

### DIFF
--- a/olsrd/Makefile
+++ b/olsrd/Makefile
@@ -34,7 +34,7 @@ endef
 define Package/olsrd
   $(call Package/olsrd/template)
   MENU:=1
-  DEPENDS:=+libpthread +libubus +iptables +IPV6:ip6tables
+  DEPENDS:=+libpthread +libubus
 endef
 
 define Package/olsrd/conffiles


### PR DESCRIPTION
Maintainer: @PolynomialDivision hi :)
Compile tested: x86_64
Run tested: x86/64

Description:

Can't use the iptables meta packages apparantly:

```
ERROR: unable to select packages:
  ip6tables (virtual):
    note: please select one of the 'provided by'
          packages explicitly
    provided by: ip6tables-nft
                 ip6tables-zz-legacy
    required by: world[ip6tables]
                 olsrd-2024.06.09~d72be9ad-r1[ip6tables]
  iptables (virtual):
    note: please select one of the 'provided by'
          packages explicitly
    provided by: iptables-nft iptables-zz-legacy
    required by: olsrd-2024.06.09~d72be9ad-r1[iptables]
```