### PR TITLE
bird2: Prevent unaligned access on ARM

### DIFF
--- a/bird2/Makefile
+++ b/bird2/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird2
 PKG_VERSION:=2.15.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://bird.network.cz/pub/bird
@@ -96,6 +96,10 @@ to BIRD, commands can perform simple actions such as enabling/disabling of
 protocols, telling BIRD to show various information, telling it to show
 a routing table filtered by a filter, or asking BIRD to reconfigure.
 endef
+
+ifeq ($(ARCH),arm)
+TARGET_CFLAGS+=-mno-unaligned-access
+endif
 
 CONFIGURE_ARGS += --disable-libssh
 


### PR DESCRIPTION
Import patch from Freifunk to enable -mno-unaligned-access - see upstream bug report:

http://trubka.network.cz/pipermail/bird-users/2024-December/017944.html

Ref: https://github.com/freifunk-berlin/falter-packages/pull/454
