### PR TITLE
batman-adv: update packages to version 2024.4

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alfred
-PKG_VERSION:=2024.3
+PKG_VERSION:=2024.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=d7114338c1a064695af71d58de03677a7219b07c55429b80f86dc03c0249ffea
+PKG_HASH:=d3a5ad906b728036e4735f9d64a72b9731f16f81f3d8df40cb478591a3bd2294
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
 PKG_LICENSE:=GPL-2.0-only MIT

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
-PKG_VERSION:=2024.3
+PKG_VERSION:=2024.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=665e655eda381415218a4d5f5fd77ff33c4fa9b5edbb7e88e839096961e3600b
+PKG_HASH:=e42bdf1a4ecb4b188bcd3aca17e120496a42b6547593b917e3ffcf943e3f2913
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
-PKG_VERSION:=2024.3
-PKG_RELEASE:=2
+PKG_VERSION:=2024.4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=b96817ed1f4f48917c32550a84faad8c87ecf53aa6f6f46cc26554b999b57ff3
+PKG_HASH:=a554df6fc7abccc6b243f56ea7b184486c95ea986db1133f87aafe237da92f21
 PKG_EXTMOD_SUBDIRS:=net/batman-adv
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/patches/0003-Revert-batman-adv-move-asm-unaligned.h-to-linux-unal.patch
+++ b/batman-adv/patches/0003-Revert-batman-adv-move-asm-unaligned.h-to-linux-unal.patch
@@ -1,0 +1,42 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Tue, 10 Dec 2024 22:31:33 +0100
+Subject: Revert "batman-adv: move asm/unaligned.h to linux/unaligned.h"
+
+This header is only available with Linux 6.12
+
+This reverts commit ee60832ebec47a023d634b06f9434103ec090aed.
+
+--- a/compat-include/linux/unaligned.h
++++ /dev/null
+@@ -1,20 +0,0 @@
+-/* SPDX-License-Identifier: GPL-2.0 */
+-/* Copyright (C) B.A.T.M.A.N. contributors:
+- *
+- * Marek Lindner, Simon Wunderlich
+- *
+- * This file contains macros for maintaining compatibility with older versions
+- * of the Linux kernel.
+- */
+-
+-#ifndef _NET_BATMAN_ADV_COMPAT_LINUX_UNALIGNED_H_
+-#define _NET_BATMAN_ADV_COMPAT_LINUX_UNALIGNED_H_
+-
+-#include <linux/version.h>
+-#if LINUX_VERSION_IS_GEQ(6, 12, 0)
+-#include_next <linux/unaligned.h>
+-#else
+-#include <asm/unaligned.h>
+-#endif
+-
+-#endif /* _NET_BATMAN_ADV_COMPAT_LINUX_UNALIGNED_H_ */
+--- a/net/batman-adv/distributed-arp-table.c
++++ b/net/batman-adv/distributed-arp-table.c
+@@ -7,7 +7,7 @@
+ #include "distributed-arp-table.h"
+ #include "main.h"
+ 
+-#include <linux/unaligned.h>
++#include <asm/unaligned.h>
+ #include <linux/atomic.h>
+ #include <linux/bitops.h>
+ #include <linux/byteorder/generic.h>

--- a/batman-adv/src/compat-hacks.h
+++ b/batman-adv/src/compat-hacks.h
@@ -5,6 +5,12 @@
 #include <linux/version.h>	/* LINUX_VERSION_CODE */
 #include <linux/types.h>
 
+#if LINUX_VERSION_IS_LESS(6, 10, 0)
+
+#define __counted_by_be(member)
+
+#endif /* LINUX_VERSION_IS_LESS(6, 10, 0) */
+
 /* <DECLARE_EWMA> */
 
 #include <linux/version.h>


### PR DESCRIPTION
Maintainer: @simonwunderlich 
Compile tested: x86_64
Run tested: x86_64

Description:

batman-adv
==========

* support latest kernels (5.4 - 6.13)
* coding style cleanups and refactoring
* bugs squashed:
   - prevent transmission of uninitialized memory for TT TVLVs
   - avoid stuck, overfull translation table changes list

batctl
======

* coding style cleanups and refactoring
* drop explicit requirement to run as root
