### PR TITLE
bird3: update to 3.0.1

### DIFF
--- a/bird3/Makefile
+++ b/bird3/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird3
-PKG_VERSION:=3.0.0
+PKG_VERSION:=3.0.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://bird.network.cz/download/
-PKG_HASH:=8130440a2e273ba6456df2fb3acb43da7cb4d566f94a294a3a52a1b118f2512a
+PKG_HASH:=8868403caa84e2554bb6e60adbe7c657e7bb7c4ac41910e398f35e236ba90fa1
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>, Nick Hainke <vincent@systemli.org>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
- Fixed crashes in dynamic BGP
- Improved graceful recovery mechanism
- Resolved issues with deterministic MED
- Addressed BFD session reconfiguration problems
- Corrected kernel path merging
- Optimized inefficiencies in feeds and refeeds
- Fixed heap bloating issues
- Corrected the name of the bgp_otc route attribute

Maintainer: me, @tohojo 
Compile tested: filogic
Run tested: tbd