### PR TITLE
[24.10] bird2: update to 2.16.1

### DIFF
--- a/bird2/Makefile
+++ b/bird2/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird2
-PKG_VERSION:=2.16
+PKG_VERSION:=2.16.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://bird.network.cz/download/
-PKG_HASH:=6629110293af6f1727967121d64f9c8dc94ed6181c4ef8b1dc51c7fdd669871c
+PKG_HASH:=f6e59cbccaca62668aea02068724bd427b9ec449c7e0f0fc5681503988c735b4
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -96,10 +96,6 @@ to BIRD, commands can perform simple actions such as enabling/disabling of
 protocols, telling BIRD to show various information, telling it to show
 a routing table filtered by a filter, or asking BIRD to reconfigure.
 endef
-
-ifeq ($(ARCH),arm)
-TARGET_CFLAGS+=-mno-unaligned-access
-endif
 
 CONFIGURE_ARGS += --disable-libssh
 


### PR DESCRIPTION
The bird package has been updated to include a patch that directly fixes the alignment issue, which previously required the use of the -mno-unaligned-access GCC flag on ARM processors. This patch, originally discussed on the BIRD mailing list [0], modifies the net_addr structure to resolve the alignment problem without needing the workaround.

By incorporating this patch, the alignment issue is addressed more efficiently, eliminating the performance, code size, and hardware optimization drawbacks associated with the GCC flag.

Release Notes:
http://trubka.network.cz/pipermail/bird-users/2025-January/018041.html

[0] - http://trubka.network.cz/pipermail/bird-users/2024-December/017957.html

Signed-off-by: Nick Hainke <vincent@systemli.org>
(cherry picked from commit 4a65e359c301d30b70e448e8c25c6edc9c909be5)

Maintainer: @tohojo 
Compile tested: filogic
Run tested: tbd