### PR TITLE
batman-adv: update packages to version 2025.0

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alfred
-PKG_VERSION:=2024.4
+PKG_VERSION:=2025.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=d3a5ad906b728036e4735f9d64a72b9731f16f81f3d8df40cb478591a3bd2294
+PKG_HASH:=c7b539699a7446ea0a18b87db85fd8f920a2bf49a702a903f800a2b72811238b
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
 PKG_LICENSE:=GPL-2.0-only MIT

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
-PKG_VERSION:=2024.4
+PKG_VERSION:=2025.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=e42bdf1a4ecb4b188bcd3aca17e120496a42b6547593b917e3ffcf943e3f2913
+PKG_HASH:=dd5f5b71dd1750eba8d69dd3adf70789741c6cf638cf2bf2ccbc2fb84f5c168f
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
-PKG_VERSION:=2024.4
+PKG_VERSION:=2025.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=a554df6fc7abccc6b243f56ea7b184486c95ea986db1133f87aafe237da92f21
+PKG_HASH:=b90c4544d3cf39f6d7cd9206126b162f5110fbb4980de96d45fbcf5033d0851a
 PKG_EXTMOD_SUBDIRS:=net/batman-adv
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/patches/0003-Revert-batman-adv-move-asm-unaligned.h-to-linux-unal.patch
+++ b/batman-adv/patches/0003-Revert-batman-adv-move-asm-unaligned.h-to-linux-unal.patch
@@ -31,12 +31,19 @@ This reverts commit ee60832ebec47a023d634b06f9434103ec090aed.
 -#endif /* _NET_BATMAN_ADV_COMPAT_LINUX_UNALIGNED_H_ */
 --- a/net/batman-adv/distributed-arp-table.c
 +++ b/net/batman-adv/distributed-arp-table.c
-@@ -7,7 +7,7 @@
+@@ -7,6 +7,7 @@
  #include "distributed-arp-table.h"
  #include "main.h"
  
--#include <linux/unaligned.h>
 +#include <asm/unaligned.h>
  #include <linux/atomic.h>
  #include <linux/bitops.h>
  #include <linux/byteorder/generic.h>
+@@ -32,7 +33,6 @@
+ #include <linux/stddef.h>
+ #include <linux/string.h>
+ #include <linux/udp.h>
+-#include <linux/unaligned.h>
+ #include <linux/workqueue.h>
+ #include <net/arp.h>
+ #include <net/genetlink.h>


### PR DESCRIPTION
Maintainer: @simonwunderlich 
Compile tested: x86_64
Run tested: x86_64

Description:

batman-adv
==========

* support latest kernels (5.4 - 6.14)
* handle VLAN 0 as untagged VLAN
* TT changes in OGMs no longer contain redundant TT changes
* coding style cleanups and refactoring
* bugs squashed:
  - fix incorrect offset in OGM handler for translation table TVLV
  - force stop of throughput detection workers on interface removal

batctl
======

* subsecond precision support for ping intervals
* coding style cleanups and refactoring

alfred
======

* coding style cleanups and refactoring
