### PR TITLE
opennds: update to version 10.3.1

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
-PKG_VERSION:=10.3.0
+PKG_VERSION:=10.3.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=5ac2ec7e4c5b860db4081895b07864bb4bf686205f0dcc3cdbd83f89e160fed8
+PKG_HASH:=f82fe0fa2e4e8ab66abf33cae7cb20e79661c8a183af82eefa11307e9c66968d
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>


### PR DESCRIPTION
Maintainer: Rob White rob@blue-wave.net

Compile tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, aarch64_cortex-a53, x86-64

Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, mips_24kc, aarch64_cortex-a53, x86-64 ;
        On 23.5, 24.10 and master/snapshot.

Description: opennds (10.3.1) - This version is a bugfix update. Most importantly, this release fixes the issue where libmicrohttpd version 1.0.0 or higher prevented the openNDS daemon from starting. Numerous other minor fixes are also included.

Details can be found here:
https://github.com/openNDS/openNDS/releases/tag/v10.3.1

Signed-off-by: Rob White <rob@blue-wave.net>
