### PR TITLE
batman-adv: update packages to version 2025.1

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alfred
-PKG_VERSION:=2025.0
+PKG_VERSION:=2025.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=c7b539699a7446ea0a18b87db85fd8f920a2bf49a702a903f800a2b72811238b
+PKG_HASH:=7fb8b3f1cc4ec488e8d43fd915dda0a7cdf5b611bf39d60ddeb4486ac0025f18
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
 PKG_LICENSE:=GPL-2.0-only MIT

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
-PKG_VERSION:=2025.0
+PKG_VERSION:=2025.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=dd5f5b71dd1750eba8d69dd3adf70789741c6cf638cf2bf2ccbc2fb84f5c168f
+PKG_HASH:=20f8a2e135a078aac16e5c8ad535a12a155cf0b79af183de5fb17da957bc2478
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
-PKG_VERSION:=2025.0
+PKG_VERSION:=2025.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=b90c4544d3cf39f6d7cd9206126b162f5110fbb4980de96d45fbcf5033d0851a
+PKG_HASH:=03ad429297961fb3acd9c2c806432d037b0ed7aac0f0a1e645e32af5210b98e1
 PKG_EXTMOD_SUBDIRS:=net/batman-adv
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>


### PR DESCRIPTION
Maintainer: @simonwunderlich 
Compile tested: x86_64
Run tested: x86_64

Description:

batman-adv
==========

* support latest kernels (5.4 - 6.15)
* added support for jumbo frames
* coding style cleanups and refactoring
* bugs squashed:
  - don't limit size of aggregated incoming OGMs
  - limit outgoing OGMs aggregates by MTU of outgoing interface

batctl
======

* coding style cleanups and refactoring

alfred
======

* coding style cleanups and refactoring
