### PR TITLE
mesh11sd: update to version 5.1.2

### DIFF
--- a/mesh11sd/Makefile
+++ b/mesh11sd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mesh11sd
-PKG_VERSION:=5.1.0
+PKG_VERSION:=5.1.2
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>
@@ -17,7 +17,7 @@ PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/mesh11sd/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=3d28d0f660bcefe065c346b4b5a144b6b05010a61f0b10e5ab78066fa7c6b941
+PKG_HASH:=9cf25ca9cbc54d0c57ceca671634ef1835f6975668287e8eb6712fe4ce8f70ba
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Maintainer: Rob White rob@blue-wave.net

Compile tested: All

Run tested: arm_cortex-a7_neon-vfpv4, mipsel_24kc, mips_24kc, aarch64_cortex-a53; On 23.5, 24.10 and master/snapshot.

Description: mesh11sd (5.1.2)

This is a minor bugfix release.
 * Improved reading of the uci config, eliminating some discrepancies.
 * Consistently use mesh_phy_index, rather then mesh_phyindex as a config option.

The full changelog can be seen here:
https://github.com/openNDS/mesh11sd/blob/v5.1.2/ChangeLog

Signed-off-by: Rob White <rob@blue-wave.net>