### PR TITLE
openwrt-24.10: batman-adv: Merge bugfixes from 2025.3

### DIFF
--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
 PKG_VERSION:=2024.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)

--- a/batctl/patches/0001-batctl-event-Fix-direct-parsing-on-hardif-for-set_ha.patch
+++ b/batctl/patches/0001-batctl-event-Fix-direct-parsing-on-hardif-for-set_ha.patch
@@ -1,0 +1,27 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Sun, 3 Aug 2025 08:48:40 +0200
+Subject: batctl: event: Fix direct parsing on hardif for set_hardif
+
+The code to get the hard interface name for an even was accidentally
+checking for BATADV_ATTR_MESH_IFNAME instead of BATADV_ATTR_HARD_IFNAME. As
+result, the fallback code was always used when BATADV_ATTR_MESH_IFNAME
+would have not been available.
+
+Luckily, at the moment, BATADV_ATTR_HARD_IFNAME is always available when
+BATADV_ATTR_MESH_IFNAME is set BATADV_CMD_SET_HARDIF events.
+
+Fixes: d12322eeb361 ("batctl: event: Get ifname from netlink message")
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batctl.git/commit/?id=03288f4f3060591dbc33600b4e5f6371d6a9f4ff
+
+--- a/event.c
++++ b/event.c
+@@ -320,7 +320,7 @@ static void event_parse_set_hardif(struc
+ 			return;
+ 	}
+ 
+-	if (attrs[BATADV_ATTR_MESH_IFNAME]) {
++	if (attrs[BATADV_ATTR_HARD_IFNAME]) {
+ 		hardif_name = nla_get_string(attrs[BATADV_ATTR_HARD_IFNAME]);
+ 	} else {
+ 		/* compatibility for Linux < 5.14/batman-adv < 2021.2 */

--- a/batctl/patches/0002-batctl-Avoid-memory-leak-in-print_routing_algos.patch
+++ b/batctl/patches/0002-batctl-Avoid-memory-leak-in-print_routing_algos.patch
@@ -1,0 +1,31 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Sun, 3 Aug 2025 08:49:12 +0200
+Subject: batctl: Avoid memory leak in print_routing_algos
+
+The opts.remaining_header string is alocated before the netlink callback
+object is created. But the callback object allocation can fail and the
+function will return in this case. To fix this, either the string buffer
+must be freed in this case or the opts.remaining_header allocation can
+simply be moved to a later point.
+
+Fixes: 0a14f8800dac ("batctl: Handle nl_cb_alloc errors")
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batctl.git/commit/?id=9363370cee11af3687ebef028f7c4518107ea424
+
+--- a/routing_algo.c
++++ b/routing_algo.c
+@@ -96,12 +96,12 @@ static int print_routing_algos(struct st
+ 	nl_send_auto_complete(state->sock, msg);
+ 	nlmsg_free(msg);
+ 
+-	opts.remaining_header = strdup("Available routing algorithms:\n");
+-
+ 	cb = nl_cb_alloc(NL_CB_DEFAULT);
+ 	if (!cb)
+ 		return -ENOMEM;
+ 
++	opts.remaining_header = strdup("Available routing algorithms:\n");
++
+ 	nl_cb_set(cb, NL_CB_VALID, NL_CB_CUSTOM, netlink_print_common_cb,
+ 		  &opts);
+ 	nl_cb_set(cb, NL_CB_FINISH, NL_CB_CUSTOM, netlink_stop_callback, NULL);

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
 PKG_VERSION:=2024.3
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)

--- a/batman-adv/patches/0011-batman-adv-fix-OOB-read-write-in-network-coding-deco.patch
+++ b/batman-adv/patches/0011-batman-adv-fix-OOB-read-write-in-network-coding-deco.patch
@@ -1,0 +1,34 @@
+From: Stanislav Fort <stanislav.fort@aisle.com>
+Date: Sun, 31 Aug 2025 16:56:23 +0200
+Subject: batman-adv: fix OOB read/write in network-coding decode
+
+batadv_nc_skb_decode_packet() trusts coded_len and checks only against
+skb->len. XOR starts at sizeof(struct batadv_unicast_packet), reducing
+payload headroom, and the source skb length is not verified, allowing an
+out-of-bounds read and a small out-of-bounds write.
+
+Validate that coded_len fits within the payload area of both destination
+and source sk_buffs before XORing.
+
+Fixes: 65aa656f3be9 ("batman-adv: network coding - receive coded packets and decode them")
+Reported-by: Stanislav Fort <disclosure@aisle.com>
+Signed-off-by: Stanislav Fort <stanislav.fort@aisle.com>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/?id=afd409d7b189044fc9bf66e50de35cb1fc08a1ee
+
+--- a/net/batman-adv/network-coding.c
++++ b/net/batman-adv/network-coding.c
+@@ -1687,7 +1687,12 @@ batadv_nc_skb_decode_packet(struct batad
+ 
+ 	coding_len = ntohs(coded_packet_tmp.coded_len);
+ 
+-	if (coding_len > skb->len)
++	/* ensure dst buffer is large enough (payload only) */
++	if (coding_len + h_size > skb->len)
++		return NULL;
++
++	/* ensure src buffer is large enough (payload only) */
++	if (coding_len + h_size > nc_packet->skb->len)
+ 		return NULL;
+ 
+ 	/* Here the magic is reversed:


### PR DESCRIPTION
Maintainer: @simonwunderlich 
Compile tested: x86-64
Run tested: x86-64

Description:


batman-adv
==========

* fix OOB read/write in network-coding decode

batctl
======

* fix potential memory leak in print_routing_algos
* fix event parsing of hard interface names
