### PR TITLE
treewide: fix maintainer naming by removing incorrect quotation marks

### DIFF
--- a/batmand/Makefile
+++ b/batmand/Makefile
@@ -17,7 +17,7 @@ PKG_SOURCE_VERSION:=2f62b17d4132f82c4716b672101eb7faa916192a
 PKG_SOURCE_DATE:=2022-12-31
 
 PKG_LICENSE:=GPL-2.0-only
-PKG_MAINTAINER:=Corinna "Elektra" Aichele <onelektra@gmx.net>
+PKG_MAINTAINER:=Corinna Aichele <onelektra@gmx.net>
 
 PKG_BUILD_PARALLEL:=1
 

--- a/vis/Makefile
+++ b/vis/Makefile
@@ -16,7 +16,7 @@ PKG_SOURCE_VERSION:=7710cce42e8d63ea114056a4a140835d4a452933
 PKG_SOURCE_URL:=https://git.open-mesh.org/vis.git
 PKG_MIRROR_HASH:=2544df816f9294e192cd6bb3592695416796fc6b254d182f1f124e686833f50d
 
-PKG_MAINTAINER:=Corinna "Elektra" Aichele <onelektra@gmx.net>
+PKG_MAINTAINER:=Corinna Aichele <onelektra@gmx.net>
 PKG_LICENSE:=GPL-2.0-only
 
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Maintainer: @BKPepe
Compile tested: no
Run tested: no

Description:

The extra quotation marks in the PKG_MAINTAINER line of the '.packageinfo'   file does not produce valid JSON when [package-metadata.pl pkgmanifestjson](https://github.com/openwrt/openwrt/blob/main/scripts/package-metadata.pl#L820) is used.

Therefore, the word with the surrounding quotation marks is removed.
