### PR TITLE
bird3: add protocol-specific build variants and Config.in

### DIFF
--- a/bird3/Config.in
+++ b/bird3/Config.in
@@ -1,0 +1,80 @@
+if PACKAGE_bird3
+
+comment "Routing protocols"
+comment "Protocols mrt, pipe, and static are always included"
+
+config BIRD3_PROTO_BGP
+	bool "BGP"
+	default y
+	help
+	  Border Gateway Protocol. Required for internet routing,
+	  route servers, and route reflectors.
+
+config BIRD3_PROTO_RPKI
+	bool "RPKI"
+	default y
+	help
+	  Route Origin Validation via the Resource Public Key
+	  Infrastructure. Used alongside BGP to validate route origins.
+
+config BIRD3_PROTO_BFD
+	bool "BFD"
+	default y
+	help
+	  Bidirectional Forwarding Detection. Provides fast link failure
+	  detection for BGP and OSPF sessions.
+
+config BIRD3_PROTO_OSPF
+	bool "OSPF"
+	default y
+	help
+	  Open Shortest Path First (OSPFv2 for IPv4, OSPFv3 for IPv6).
+	  Common interior gateway protocol for enterprise and ISP networks.
+
+config BIRD3_PROTO_BABEL
+	bool "Babel"
+	default y
+	help
+	  Babel routing protocol. Distance-vector protocol suitable for
+	  mesh and wireless networks.
+
+config BIRD3_PROTO_RIP
+	bool "RIP"
+	default y
+	help
+	  Routing Information Protocol (RIPv2 for IPv4, RIPng for IPv6).
+
+config BIRD3_PROTO_RADV
+	bool "RAdv"
+	default y
+	help
+	  IPv6 Router Advertisements. Announces IPv6 prefixes and router
+	  information to hosts on the link.
+
+config BIRD3_PROTO_AGGREGATOR
+	bool "Aggregator"
+	default y
+	help
+	  Route aggregation protocol. Merges multiple routes into
+	  aggregate prefixes, typically used with BGP.
+
+config BIRD3_PROTO_BMP
+	bool "BMP"
+	default n
+	help
+	  BGP Monitoring Protocol. Streams BGP session state to a
+	  monitoring station. Rarely needed on embedded routers.
+
+config BIRD3_PROTO_L3VPN
+	bool "L3VPN"
+	default n
+	help
+	  MPLS/L3VPN support. Required for BGP-based MPLS VPNs.
+
+config BIRD3_PROTO_PERF
+	bool "PERF"
+	default n
+	help
+	  Performance testing protocol. Not intended for production use.
+
+endif

--- a/bird3/Makefile
+++ b/bird3/Makefile
@@ -14,38 +14,85 @@ PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>, Nick Hainke <vincent@sy
 PKG_LICENSE:=GPL-2.0-or-later
 
 PKG_BUILD_DEPENDS:=ncurses readline
-PKG_BUILD_DIR:=$(BUILD_DIR)/bird-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/bird-$(PKG_VERSION)
+
+PKG_CONFIG_DEPENDS := \
+	CONFIG_BIRD3_PROTO_AGGREGATOR \
+	CONFIG_BIRD3_PROTO_BABEL \
+	CONFIG_BIRD3_PROTO_BFD \
+	CONFIG_BIRD3_PROTO_BGP \
+	CONFIG_BIRD3_PROTO_BMP \
+	CONFIG_BIRD3_PROTO_L3VPN \
+	CONFIG_BIRD3_PROTO_OSPF \
+	CONFIG_BIRD3_PROTO_PERF \
+	CONFIG_BIRD3_PROTO_RADV \
+	CONFIG_BIRD3_PROTO_RIP \
+	CONFIG_BIRD3_PROTO_RPKI
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/bird3
-  TITLE:=The BIRD Internet Routing Daemon (v3)
+BUILD_VARIANT?=full
+
+# Infrastructure protocols included in every variant unconditionally.
+BIRD3_INFRA := mrt,pipe,static
+
+# Predefined protocol sets for prebuilt package variants
+BIRD3_PROTOCOLS_bgp   := bgp,rpki,bfd,$(BIRD3_INFRA)
+BIRD3_PROTOCOLS_ospf  := ospf,bfd,$(BIRD3_INFRA)
+BIRD3_PROTOCOLS_babel := babel,$(BIRD3_INFRA)
+BIRD3_PROTOCOLS_mesh  := babel,bgp,$(BIRD3_INFRA)
+
+# For the full variant, assemble the protocol list from Config.in selections.
+ifeq ($(BUILD_VARIANT),full)
+  BIRD3_PROTOCOLS := $(BIRD3_INFRA)
+  ifdef CONFIG_BIRD3_PROTO_AGGREGATOR
+    BIRD3_PROTOCOLS := $(BIRD3_PROTOCOLS),aggregator
+  endif
+  ifdef CONFIG_BIRD3_PROTO_BABEL
+    BIRD3_PROTOCOLS := $(BIRD3_PROTOCOLS),babel
+  endif
+  ifdef CONFIG_BIRD3_PROTO_BFD
+    BIRD3_PROTOCOLS := $(BIRD3_PROTOCOLS),bfd
+  endif
+  ifdef CONFIG_BIRD3_PROTO_BGP
+    BIRD3_PROTOCOLS := $(BIRD3_PROTOCOLS),bgp
+  endif
+  ifdef CONFIG_BIRD3_PROTO_BMP
+    BIRD3_PROTOCOLS := $(BIRD3_PROTOCOLS),bmp
+  endif
+  ifdef CONFIG_BIRD3_PROTO_L3VPN
+    BIRD3_PROTOCOLS := $(BIRD3_PROTOCOLS),l3vpn
+  endif
+  ifdef CONFIG_BIRD3_PROTO_OSPF
+    BIRD3_PROTOCOLS := $(BIRD3_PROTOCOLS),ospf
+  endif
+  ifdef CONFIG_BIRD3_PROTO_PERF
+    BIRD3_PROTOCOLS := $(BIRD3_PROTOCOLS),perf
+  endif
+  ifdef CONFIG_BIRD3_PROTO_RADV
+    BIRD3_PROTOCOLS := $(BIRD3_PROTOCOLS),radv
+  endif
+  ifdef CONFIG_BIRD3_PROTO_RIP
+    BIRD3_PROTOCOLS := $(BIRD3_PROTOCOLS),rip
+  endif
+  ifdef CONFIG_BIRD3_PROTO_RPKI
+    BIRD3_PROTOCOLS := $(BIRD3_PROTOCOLS),rpki
+  endif
+else
+  BIRD3_PROTOCOLS := $(BIRD3_PROTOCOLS_$(BUILD_VARIANT))
+endif
+
+CONFIGURE_ARGS += --disable-libssh --with-protocols=$(BIRD3_PROTOCOLS)
+TARGET_LDFLAGS += -latomic
+
+define Package/bird3/Default
   URL:=https://bird.nic.cz/
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Routing and Redirection
   DEPENDS:=+libpthread +libatomic
   CONFLICTS:=bird2
-endef
-
-define Package/bird3c
-  TITLE:=The BIRD command-line client (v3)
-  URL:=https://bird.nic.cz/
-  SECTION:=net
-  CATEGORY:=Network
-  SUBMENU:=Routing and Redirection
-  DEPENDS:=+bird3 +libreadline +libncurses
-  CONFLICTS:=bird2
-endef
-
-define Package/bird3cl
-  TITLE:=The BIRD lightweight command-line client (v2)
-  URL:=https://bird.nic.cz/
-  SECTION:=net
-  CATEGORY:=Network
-  SUBMENU:=Routing and Redirection
-  DEPENDS:=+bird3
-  CONFLICTS:=bird2
+  PROVIDES:=bird3
 endef
 
 define Package/bird3/Default/description
@@ -53,6 +100,17 @@ BIRD is an internet routing daemon which manages TCP/IP routing tables
 with support of modern routing protocols, easy to use configuration
 interface and powerful route filtering language. It is lightweight and
 efficient and therefore appropriate for small embedded routers.
+endef
+
+define Package/bird3
+  $(call Package/bird3/Default)
+  TITLE:=The BIRD Internet Routing Daemon (v3)
+  VARIANT:=full
+  CONFLICTS:=bird2 bird3-bgp bird3-ospf bird3-babel bird3-mesh
+endef
+
+define Package/bird3/config
+  source "$(SOURCE)/Config.in"
 endef
 
 define Package/bird3/description
@@ -70,9 +128,59 @@ configuration syntax.
 This is the 3.0 branch of Bird which is a multithreaded rewrite.
 endef
 
-define Package/bird3c/description
+define Package/bird3-bgp
+  $(call Package/bird3/Default)
+  TITLE:=The BIRD Internet Routing Daemon (v3) - BGP/RPKI/BFD
+  VARIANT:=bgp
+  CONFLICTS:=bird2 bird3 bird3-ospf bird3-babel bird3-mesh
+endef
+
+Package/bird3-bgp/description = $(Package/bird3/Default/description)
+
+define Package/bird3-ospf
+  $(call Package/bird3/Default)
+  TITLE:=The BIRD Internet Routing Daemon (v3) - OSPF/BFD
+  VARIANT:=ospf
+  CONFLICTS:=bird2 bird3 bird3-bgp bird3-babel bird3-mesh
+endef
+
+Package/bird3-ospf/description = $(Package/bird3/Default/description)
+
+define Package/bird3-babel
+  $(call Package/bird3/Default)
+  TITLE:=The BIRD Internet Routing Daemon (v3) - Babel
+  VARIANT:=babel
+  CONFLICTS:=bird2 bird3 bird3-bgp bird3-ospf bird3-mesh
+endef
+
+Package/bird3-babel/description = $(Package/bird3/Default/description)
+
+define Package/bird3-mesh
+  $(call Package/bird3/Default)
+  TITLE:=The BIRD Internet Routing Daemon (v3) - Babel+BGP mesh
+  VARIANT:=mesh
+  CONFLICTS:=bird2 bird3 bird3-bgp bird3-ospf bird3-babel
+endef
+
+define Package/bird3-mesh/description
 $(call Package/bird3/Default/description)
 
+Size-optimized variant for mesh networks running Babel for routing and
+BGP for overlay services such as hostname distribution.
+endef
+
+define Package/bird3c
+  TITLE:=The BIRD command-line client (v3)
+  URL:=https://bird.nic.cz/
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  DEPENDS:=+bird3 +libreadline +libncurses
+  CONFLICTS:=bird2
+  VARIANT:=full
+endef
+
+define Package/bird3c/description
 This is a BIRD command-line client. It is used to send commands to BIRD,
 commands can perform simple actions such as enabling/disabling of
 protocols, telling BIRD to show various information, telling it to show
@@ -82,23 +190,34 @@ Unless you can't afford dependency on ncurses and readline, you
 should install BIRD command-line client together with BIRD.
 endef
 
-define Package/bird3cl/description
-$(call Package/bird3/Default/description)
+define Package/bird3cl
+  TITLE:=The BIRD lightweight command-line client (v3)
+  URL:=https://bird.nic.cz/
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  DEPENDS:=+bird3
+  CONFLICTS:=bird2
+  VARIANT:=full
+endef
 
+define Package/bird3cl/description
 This is a BIRD lightweight command-line client. It is used to send commands
 to BIRD, commands can perform simple actions such as enabling/disabling of
 protocols, telling BIRD to show various information, telling it to show
 a routing table filtered by a filter, or asking BIRD to reconfigure.
 endef
 
-CONFIGURE_ARGS += --disable-libssh
-TARGET_LDFLAGS += -latomic
-
 define Package/bird3/conffiles
 /etc/bird.conf
 /etc/bird4.conf
 /etc/bird6.conf
 endef
+
+Package/bird3-bgp/conffiles   = $(Package/bird3/conffiles)
+Package/bird3-ospf/conffiles  = $(Package/bird3/conffiles)
+Package/bird3-babel/conffiles = $(Package/bird3/conffiles)
+Package/bird3-mesh/conffiles  = $(Package/bird3/conffiles)
 
 define Package/bird3/install
 	$(INSTALL_DIR)  $(1)/usr/sbin
@@ -108,6 +227,11 @@ define Package/bird3/install
 	$(INSTALL_DIR)  $(1)/etc/init.d
 	$(INSTALL_BIN)  ./files/bird.init $(1)/etc/init.d/bird
 endef
+
+Package/bird3-bgp/install   = $(Package/bird3/install)
+Package/bird3-ospf/install  = $(Package/bird3/install)
+Package/bird3-babel/install = $(Package/bird3/install)
+Package/bird3-mesh/install  = $(Package/bird3/install)
 
 define Package/bird3c/install
 	$(INSTALL_DIR) $(1)/usr/sbin
@@ -120,5 +244,9 @@ define Package/bird3cl/install
 endef
 
 $(eval $(call BuildPackage,bird3))
+$(eval $(call BuildPackage,bird3-bgp))
+$(eval $(call BuildPackage,bird3-ospf))
+$(eval $(call BuildPackage,bird3-babel))
+$(eval $(call BuildPackage,bird3-mesh))
 $(eval $(call BuildPackage,bird3c))
 $(eval $(call BuildPackage,bird3cl))


### PR DESCRIPTION
Bird's binary size is dominated by compiled-in routing protocols. This adds size-optimized package variants built with --with-protocols so users on flash-constrained devices can install only what they need without recompiling.

New packages:
- bird3-bgp:   BGP, RPKI, BFD + infrastructure (mrt, pipe, static)
- bird3-ospf:  OSPF, BFD + infrastructure
- bird3-babel: Babel + infrastructure
- bird3-mesh:  Babel, BGP, RPKI, BFD + infrastructure, for mesh
               networks using BGP-based overlay services (e.g. hostname
               distribution via bgpdisco)

All variants PROVIDE:=bird3 so existing DEPENDS:=+bird3 continue to work. They conflict with each other since all install /usr/sbin/bird.

For users building from source, Config.in adds per-protocol checkboxes under the bird3 menu in menuconfig. Protocols default to enabled to preserve existing behaviour, builders on tight flash budgets can uncheck what they do not need. PKG_CONFIG_DEPENDS ensures bird3 is rebuilt when the selection changes.

Maintainer: me, @tohojo 
Compile tested: tbd
Run tested: tbd
