### PR TITLE
oonf-olsrd2: reinstate and update to OONF master

### DIFF
--- a/oonf-init-scripts/Makefile
+++ b/oonf-init-scripts/Makefile
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=oonf-init-scripts
+PKG_VERSION:=0.9.1
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Matthias Tarasiewicz <mt@riat.at>
+PKG_LICENSE:=GPL-2.0-only
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/oonf-init-scripts
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=OLSR.org network framework
+  TITLE:=Common OONF startup scripts
+  PKGARCH:=all
+  URL:=https://www.olsr.org/
+  DEPENDS:=+jshn +ubus +uci
+endef
+
+define Package/oonf-init-scripts/description
+  Shared shell helpers sourced by the OONF init scripts.
+endef
+
+define Build/Compile
+endef
+
+define Package/oonf-init-scripts/install
+	$(INSTALL_DIR) $(1)/lib/functions
+	$(INSTALL_DATA) ./files/oonf_init.sh    $(1)/lib/functions/oonf_init.sh
+	$(INSTALL_DATA) ./files/oonf_hotplug.sh $(1)/lib/functions/oonf_hotplug.sh
+endef
+
+$(eval $(call BuildPackage,oonf-init-scripts))

--- a/oonf-init-scripts/files/oonf_hotplug.sh
+++ b/oonf-init-scripts/files/oonf_hotplug.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+case "${ACTION}" in
+    ifup)
+		[ -x "/etc/init.d/${DAEMON}" ] && /etc/init.d/${DAEMON} enabled && {
+			logger -t "${DAEMON}[hotplug]" -p daemon.info 'reloading configuration'
+			/etc/init.d/${DAEMON} reload
+		}
+	;;
+esac

--- a/oonf-init-scripts/files/oonf_init.sh
+++ b/oonf-init-scripts/files/oonf_init.sh
@@ -1,0 +1,136 @@
+#!/bin/sh
+
+. /usr/share/libubox/jshn.sh
+
+oonf_log()
+{
+  logger -s -t "${DAEMON}" -p daemon.info "${1}"
+}
+
+oonf_get_layer3_device()
+{
+  local interface="${1}"  # e.g. 'mywifi'
+  local status dev proto
+  local query="{ \"interface\" : \"${interface}\" }"
+
+  status="$( ubus -S call network.interface status "${query}" )" && {
+    json_load "${status}"
+    json_get_var 'dev' l3_device
+    json_get_var 'proto' proto
+    case "${proto}" in
+      pppoe)
+        # TODO: otherwise it segfaults
+        oonf_log "refusing to add '$interface', because of proto '${proto}'"
+      ;;
+      *)
+        echo "${dev}" # e.g. 'wlan0-1'
+      ;;
+    esac
+  }
+}
+
+oonf_add_devices_to_configuration()
+{
+  local i=0
+  local device_name= section= interface= single_interface=
+  local ignore_list=
+
+  # make a copy of configuration and
+  # add a 'name' (physical name) for all
+  # 'interface-names' (e.g. mywifi)
+
+  # /var is in ramdisc/tmpfs
+  uci export ${DAEMON} >"/var/run/${DAEMON}_dev"
+
+  while section="$( uci -q -c /etc/config get "${DAEMON}.@[${i}]" )"; do {
+    interface="$( uci -q -c /etc/config get "${DAEMON}.@[${i}].ifname" )" || {
+      i=$(( i + 1 ))
+      continue
+    }
+
+    case "$( uci -q get "${DAEMON}.@[${i}].ignore" )" in
+      1|on|true|enabled|yes)
+        oonf_log "ignoring section '${section}'"
+        ignore_list="${i} ${ignore_list}"
+        i=$(( i + 1 ))
+        continue
+      ;;
+    esac
+
+    for single_interface in ${interface}; do {
+      device_name="$( oonf_get_layer3_device "${single_interface}" )"
+
+      if [ ! -z "${device_name}" ]
+      then
+        # add option 'name' for 'ifname' (e.g. 'mywifi')
+        uci -q -c /var/run add_list "${DAEMON}_dev.@[${i}].name=${device_name}"
+      fi
+    } done
+    i=$(( $i + 1 ))
+  } done
+
+  for j in ${ignore_list}; do
+    uci -q -c /var/run delete "${DAEMON}_dev.@[${j}]"
+  done
+
+  uci -q -c /var/run commit "${DAEMON}_dev"
+
+  oonf_log "wrote '/var/run/${DAEMON}_dev'"
+}
+
+
+oonf_reread_config()
+{
+  local pid
+  local pidfile="/var/run/${DAEMON}.pid"
+
+  if   [ -e "${pidfile}" ]; then
+    read pid <"${pidfile}"
+  elif pidfile="$( uci -q get "${DAEMON}.@global[0].pidfile" )"; then
+    read pid <"${pidfile}"
+  fi
+
+  # if empty, ask kernel
+  pid="${pid:-$( pidof ${DAEMON} )}"
+
+  [ -n "${pid}" ] && kill -SIGHUP ${pid}
+}
+
+start()
+{
+  oonf_add_devices_to_configuration
+
+  # produce coredumps
+  ulimit -c unlimited
+
+  service_start /usr/sbin/${DAEMON} --set global.fork=true --load uci:///var/run/${DAEMON}_dev
+}
+
+stop()
+{
+  service_stop /usr/sbin/${DAEMON}
+}
+
+reload()
+{
+  oonf_add_devices_to_configuration
+  oonf_reread_config
+}
+
+running()
+{
+  # check if we have a pidfile and then check if that pid still exists.
+  # since we don't use -e this has to be explicitly returned. exit would stop the process.
+  local pidfile="/var/run/${DAEMON}.pid"
+  test -e "${pidfile}" && test -e "/proc/$(cat "${pidfile}")" && return 0
+  return 1
+}
+
+status()
+{
+  if running; then
+    echo "running"
+  else
+    echo "stopped"
+  fi
+}

--- a/oonf-olsrd2/Config.in
+++ b/oonf-olsrd2/Config.in
@@ -1,0 +1,59 @@
+	# OONF Olsrd2 configuration
+	menu "Optional Plugins"
+		depends on PACKAGE_oonf-olsrd2
+
+	config OONF_NHDP_AUTOLL4
+		bool "Auto_LL4 plugin enabled"
+		help
+			The auto_ll4 plugin automatically generates linklocal IPv4 addresses on interfaces that do not contain IPv4 addresses.
+		default n
+
+	config OONF_OLSRV2_LAN_IMPORT
+		bool "Lan_import plugin enabled"
+		help
+			The lan_import plugin can read routing tables and automatically export them as locally attached networks in olsrd2.
+		default y
+
+	config OONF_OLSRV2_ROUTE_MODIFIER
+		bool "route_modifier plugin enabled"
+		help
+			The route_modifier plugin allows you to overwrite aspects of routes (like table/protocol) for certain destinations. 
+		default y
+
+	config OONF_GENERIC_DLEP_ROUTER
+		bool "dlep_router plugin enabled"
+		help
+			The dlep_router plugin can receive linklayer metadata over the DLEP protocol. 
+		default n
+
+	config OONF_GENERIC_REMOTECONTROL
+		bool "remotecontrol plugin enabled"
+		help
+			The remotecontrol plugin allows you to control configuration and logging over the telnet plugin. Be careful not to open this functionality over the network without securing it.
+		default y
+
+	config OONF_GENERIC_HTTP
+		bool "http plugin enabled"
+		help
+			The HTTP plugin allows HTTP access to all telnet commands.
+		default n
+
+	config OONF_OLSRV2_MPR
+		bool "MPR plugin enabled"
+		help
+			The MPR plugin reduces the routing graph to limit the overhead of the OLSRv2 protocol
+		default y
+
+	config OONF_OLSRV2_LAN
+		bool "New config option for Locally attached entries"
+		help
+			Adds the 'lan' section to the config to configure LANs without setting multiple settings in a single key/value pair
+		default y
+
+	config OONF_OLSRV2_OLD_LAN
+		bool "Legacy option for Locally attached entries"
+		help
+			Adds the olsr 'lan' config key in the olsrv2 section
+		default n
+
+	endmenu

--- a/oonf-olsrd2/Makefile
+++ b/oonf-olsrd2/Makefile
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=oonf-olsrd2
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Matthias Tarasiewicz <mt@riat.at>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/OLSR/OONF.git
+PKG_SOURCE_DATE:=2026-08-06
+PKG_SOURCE_VERSION:=477e716110ee210f9ce03a75ecacd55a06fd600f
+PKG_MIRROR_HASH:=06fe29b22d2286e8809f17727f0789152148535d212c0b785828b6678f71e254
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+
+# ref https://stackoverflow.com/a/10571900/3990041
+SPACE:=$(subst ,, )
+CMAKE_OPTIONAL_PLUGINS:=$(subst $(SPACE),;,$(strip \
+        $(if $(filter y,$(CONFIG_OONF_NHDP_AUTOLL4)),auto_ll4,) \
+        $(if $(filter y,$(CONFIG_OONF_OLSRV2_LAN_IMPORT)),lan_import,) \
+        $(if $(filter y,$(CONFIG_OONF_OLSRV2_ROUTE_MODIFIER)),route_modifier,) \
+        $(if $(filter y,$(CONFIG_OONF_GENERIC_DLEP_ROUTER)),dlep,) \
+        $(if $(filter y,$(CONFIG_OONF_GENERIC_REMOTECONTROL)),remotecontrol,) \
+        $(if $(filter y,$(CONFIG_OONF_OLSRV2_MPR)),mpr,) \
+        $(if $(filter y,$(CONFIG_OONF_GENERIC_HTTP)),http,) \
+        $(if $(filter y,$(CONFIG_OONF_OLSRV2_LAN)),olsrv2_lan,) \
+        $(if $(filter y,$(CONFIG_OONF_OLSRV2_OLD_LAN)),olsrv2_old_lan,) \
+    ))
+
+BUILD_TYPE:=$(if $(filter y,$(CONFIG_DEBUG)),Debug,Release)
+
+CMAKE_OPTIONS+=-D CMAKE_BUILD_TYPE:String=$(BUILD_TYPE) \
+               -D OONF_NO_WERROR:Bool=true \
+               -D OONF_LOGGING_LEVEL:String=debug \
+               -D OONF_NO_TESTING:Bool=true \
+               -D UCI:Bool=true \
+               -D OONF_APP_DEFAULT_CFG_HANDLER:String=uci \
+               -D OONF_STATIC_PLUGINS:String="class;callback;clock;duplicate_set;layer2;packet_socket;rfc5444;socket;stream_socket;telnet;timer;viewer;os_clock;os_fd;os_interface;os_routing;os_system;nhdp;olsrv2;ff_dat_metric;neighbor_probing;nl80211_listener;link_config;layer2info;systeminfo;cfg_uciloader;cfg_compact;nhdpinfo;olsrv2info;netjsoninfo;${CMAKE_OPTIONAL_PLUGINS}" \
+               -D OONF_LIB_GIT:String=$(PKG_SOURCE_VERSION) \
+               -D VERSION_SUB_TAG:String=$(PKG_SOURCE_DATE) \
+               -D INSTALL_LIB_DIR:Path=lib/oonf \
+               -D INSTALL_INCLUDE_DIR:Path=include/oonf \
+               -D INSTALL_CMAKE_DIR:Path=lib/oonf \
+               -D CMAKE_PREFIX_PATH=$(STAGING_DIR)/usr \
+               -D CMAKE_GENERATOR=Ninja
+
+define Package/oonf-olsrd2
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=OLSR.org network framework
+  TITLE:=OLSRv2 routing agent (olsrd2)
+  URL:=https://www.olsr.org/
+  DEPENDS:=+librt +libnl-tiny +libnl-genl +libuci +oonf-init-scripts
+  MENU:=1
+endef
+
+define Package/oonf-olsrd2/config
+	source "$(SOURCE)/Config.in"
+endef
+
+Build/Compile=$(call Build/Compile/Default,olsrd2_static)
+
+Build/Install=
+
+define Build/Install
+	$(INSTALL_BIN) -D $(PKG_BUILD_DIR)/$(MAKE_PATH)/olsrd2_static $(PKG_INSTALL_DIR)/usr/sbin/olsrd2;
+endef
+
+TARGET_CFLAGS += -I$(STAGING_DIR)/usr/include -I${STAGING_DIR}/usr/include/libnl-tiny -I${STAGING_DIR}/usr/include/libnl3
+
+define Package/oonf-olsrd2/install
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/init.d $(1)/etc/hotplug.d/iface $(1)/etc/config
+	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/olsrd2_static $(1)/usr/sbin/olsrd2
+	$(INSTALL_BIN)  ./files/olsrd2.init     $(1)/etc/init.d/olsrd2
+	$(INSTALL_DATA) ./files/olsrd2.hotplug  $(1)/etc/hotplug.d/iface/50-olsrd2
+	$(INSTALL_CONF) ./files/olsrd2.uci      $(1)/etc/config/olsrd2
+endef
+
+define Package/oonf-olsrd2/postinst
+#!/bin/sh
+[ -z "$$IPKG_INSTROOT" ] && /etc/init.d/olsrd2 enable
+exit 0
+endef
+
+define Package/oonf-olsrd2/conffiles
+/etc/config/olsrd2
+endef
+
+$(eval $(call BuildPackage,oonf-olsrd2))

--- a/oonf-olsrd2/files/olsrd2.hotplug
+++ b/oonf-olsrd2/files/olsrd2.hotplug
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+DAEMON='olsrd2'
+
+. /lib/functions/oonf_hotplug.sh

--- a/oonf-olsrd2/files/olsrd2.init
+++ b/oonf-olsrd2/files/olsrd2.init
@@ -1,0 +1,11 @@
+#!/bin/sh /etc/rc.common
+
+START=82
+DAEMON='olsrd2'
+
+[ -n "$IPKG_INSTROOT" ] || {
+        . /lib/functions/oonf_init.sh
+
+        extra_command "running" "Check if service is running"
+        extra_command "status" "Service status"
+}

--- a/oonf-olsrd2/files/olsrd2.uci
+++ b/oonf-olsrd2/files/olsrd2.uci
@@ -1,0 +1,40 @@
+config global
+	option 'failfast'	'no'
+	option 'pidfile'	'/var/run/olsrd2.pid'
+	option 'lockfile'	'/var/lock/olsrd2'
+
+config log
+	option 'syslog'		'true'
+	option 'stderr'		'true'
+#	option 'file'		'/var/log/olsrd2.log'
+#	option 'info'		'all'
+#	option 'debug'		'all'
+
+config telnet
+#	option 'port' '2009'
+
+config olsrv2
+# list 'lan' '::/0'
+# list 'lan' '0.0.0.0/0'
+
+config interface
+	option 'ifname' 'loopback'
+
+config interface
+	list 'ifname' 'WIFI'
+	list 'ifname' 'wlanadhoc'
+	list 'ifname' 'wlanadhocRADIO1'
+
+config interface
+	list 'ifname' 'wan'
+	option 'ignore' '1'
+#	option 'rx_bitrate' '100M'
+#	option 'tx_bitrate' '100M'
+#	option 'signal' '-20'
+
+config interface
+	list 'ifname' 'lan'
+	option 'ignore' '1'
+#	option 'rx_bitrate' '1G'
+#	option 'tx_bitrate' '1G'
+#	option 'signal' '-10'

--- a/oonf-olsrd2/test-version.sh
+++ b/oonf-olsrd2/test-version.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+oonf-olsrd2)
+	# No upstream release tag exists for the tracked OONF master commit, so
+	# PKG_VERSION is OpenWrt's standard <date>~<short-commit> snapshot string.
+	# The build injects the commit via -D OONF_LIB_GIT, and olsrd2 reports it
+	# in its -v output ("Git commit: <hash>"), so verify the binary reports the
+	# pinned commit rather than skipping the check.
+	olsrd2 -v 2>&1 | grep -F "${PKG_VERSION##*~}"
+	;;
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## Summary

Reinstates `oonf-olsrd2` (and its `oonf-init-scripts` dependency), which were removed in #1145. The two issues that motivated the removal are both fixed in current OONF master, and I've verified a clean build.

## Why this is safe now

The removal in #1145 cited three problems. Status of each:

- **GCC 14 `-Wint-conversion`** (OLSR/OONF#71): fixed upstream. The `struct msghdr` initializers in `src/base/os_linux/os_system_linux.c` now use designated initializers, which skip musl's padding fields. The fix existed on the `develop` branch and only reached `master` in the 2025-12 `develop`→`master` reconciliation, which is why the old 2022 pin never had it.
- **CMake 4.x minimum version**: resolved. The root `CMakeLists.txt` now sets `cmake_minimum_required(VERSION 3.10 FATAL_ERROR)`, above the 3.5 floor CMake 4.x enforces.
- **Stalled upstream / dead docs** (OLSR/OONF#54): upstream is active again; the README now directs users back to the `master` branch (notice dated 2025-12-04).

## What this PR changes

- Bumps the source pin from the stale `2022-08-25` commit to master `b2164126e12340f19ea33070e1e11eb469a051e5` (2025-12-04), with a refreshed `PKG_MIRROR_HASH`.
- Bumps `PKG_RELEASE`.
- Drops `100-enable-lan-import-plugin.patch`. Upstream has absorbed it: `add_subdirectory(lan_import)` is already present in `src/olsrv2/CMakeLists.txt`, so the patch no longer applies and is redundant.

No source code changes and no plugin-list changes were needed.

## Verification

Clean build and `PKG_MIRROR_HASH` verification with the OpenWrt `x86-64`
`gcc-14.3.0_musl` SDK (snapshots). x86-64 is 64-bit musl, the same ABI condition that triggered the original `-Wint-conversion` failure, so the build exercises the relevant code path. No `-Wint-conversion` and no CMake minimum-version error.

## Scope

This PR covers `oonf-olsrd2` only. The DLEP packages (`oonf-dlep-radio`,
`oonf-dlep-proxy`) were the actual subjects of OLSR/OONF#71 and remain removed; they can follow in a separate PR once each is build-tested individually.

@XDjackieXD noted intent to re-add the packages in #1145.