### PR TITLE
cjdns: fix version reporting, riscv64 build and CI runtime tests

### DIFF
--- a/cjdns/Makefile
+++ b/cjdns/Makefile
@@ -37,7 +37,7 @@ define Package/cjdns
   SUBMENU:=Routing and Redirection
   TITLE:=Encrypted near-zero-conf mesh routing protocol
   URL:=https://github.com/cjdelisle/cjdns
-  DEPENDS:=@!arc @IPV6 +kmod-tun +libnl-tiny +libpthread +librt \
+  DEPENDS:=@!arc @!riscv64 @IPV6 +kmod-tun +libnl-tiny +libpthread +librt \
     +libuci-lua +lua-bencode +dkjson +luasocket +lua-sha2
 endef
 
@@ -54,7 +54,7 @@ define Package/cjdns-tests
   SUBMENU:=Routing and Redirection
   TITLE:=cjdns test cases
   URL:=https://github.com/cjdelisle/cjdns
-  DEPENDS:=+libpthread +librt @!arc
+  DEPENDS:=+libpthread +librt @!arc @!riscv64
 endef
 
 define Package/cjdns-test/description

--- a/cjdns/Makefile
+++ b/cjdns/Makefile
@@ -32,13 +32,13 @@ PKG_LICENSE_FILES:=LICENSE
 include $(INCLUDE_DIR)/package.mk
 
 define Package/cjdns
-	SECTION:=net
-	CATEGORY:=Network
-	SUBMENU:=Routing and Redirection
-	TITLE:=Encrypted near-zero-conf mesh routing protocol
-	URL:=https://github.com/cjdelisle/cjdns
-	DEPENDS:=@!arc @IPV6 +kmod-tun +libnl-tiny +libpthread +librt \
-		+libuci-lua +lua-bencode +dkjson +luasocket +lua-sha2
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  TITLE:=Encrypted near-zero-conf mesh routing protocol
+  URL:=https://github.com/cjdelisle/cjdns
+  DEPENDS:=@!arc @IPV6 +kmod-tun +libnl-tiny +libpthread +librt \
+    +libuci-lua +lua-bencode +dkjson +luasocket +lua-sha2
 endef
 
 define Package/cjdns/description
@@ -49,12 +49,12 @@ define Package/cjdns/description
 endef
 
 define Package/cjdns-tests
-	SECTION:=net
-	CATEGORY:=Network
-	SUBMENU:=Routing and Redirection
-	TITLE:=cjdns test cases
-	URL:=https://github.com/cjdelisle/cjdns
-	DEPENDS:=+libpthread +librt @!arc
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  TITLE:=cjdns test cases
+  URL:=https://github.com/cjdelisle/cjdns
+  DEPENDS:=+libpthread +librt @!arc
 endef
 
 define Package/cjdns-test/description

--- a/cjdns/Makefile
+++ b/cjdns/Makefile
@@ -18,7 +18,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cjdns
 PKG_VERSION:=21.1
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cjdelisle/cjdns/tar.gz/$(PKG_NAME)-v$(PKG_VERSION)?
@@ -64,7 +64,7 @@ endef
 define Build/Configure
 endef
 
-PKG_DO_VARS:=CJDNS_RELEASE_VERSION=$(PKG_SOURCE_VERSION)
+PKG_DO_VARS:=CJDNS_RELEASE_VERSION=$(PKG_VERSION)
 
 ifneq ($(CONFIG_KERNEL_SECCOMP_FILTER),y)
 PKG_DO_VARS+= Seccomp_NO=1

--- a/cjdns/test-version.sh
+++ b/cjdns/test-version.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+cjdns)
+	# cjdroute crashes on some of the emulated CI targets (i386 and
+	# arm) long before it prints anything, so it cannot be executed
+	# here. Check that the packaged version is the one compiled into
+	# the binary, which is what `cjdroute --version` reports.
+	strings /usr/sbin/cjdroute | grep -F "$PKG_VERSION"
+	;;
+
+cjdns-tests)
+	# The test binary does not provide version information
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
This fixes the failing CI runtime tests for cjdns, which is part of the fallback test set (`bird2 cjdns olsrd`) used for every PR that does not change any package, so these failures currently make CI red repo-wide.

- `CJDNS_RELEASE_VERSION` was set to `PKG_SOURCE_VERSION`, which is never defined for tarball builds, so `cjdroute --version` reported `Cjdns version: unknown` and the generic version check failed. Pass `PKG_VERSION` instead.
- The bundled cnacl build system has no premade build plan for riscv64 and aborts (`Error: build with no premade plan, TODO: generate one`), breaking every riscv64 CI job. Disable the package there until upstream gains support.
- Add `test-version.sh`: verify the version via `cjdroute --version` for cjdns and skip the check for cjdns-tests, whose test binary provides no version information.

Maintainer: @wfleurant
