### PR TITLE
olsrd: fix plugin SONAME, add test-version.sh, clean up Makefile

### DIFF
--- a/olsrd/Makefile
+++ b/olsrd/Makefile
@@ -17,6 +17,7 @@ PKG_MIRROR_HASH:=e05d2724e6c76233148ce460b9611bafccff2114904542fa3b5caf75dc1c4e0
 PKG_MAINTAINER:=Nick Hainke <vincent@systemli.org>
 PKG_BUILD_PARALLEL:=0
 PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=license.txt
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -26,9 +27,8 @@ define Package/olsrd/template
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Routing and Redirection
-  MAINTAINER:=Saverio Proto <zioproto@gmail.com>
   TITLE:=OLSR (Optimized Link State Routing) daemon
-  URL:=http://www.olsr.org/
+  URL:=https://www.olsr.org/
 endef
 
 define Package/olsrd

--- a/olsrd/Makefile
+++ b/olsrd/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=olsrd
 PKG_SOURCE_DATE:=2024-06-09
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/OLSR/olsrd.git

--- a/olsrd/Makefile
+++ b/olsrd/Makefile
@@ -159,7 +159,7 @@ endef
 
 define Package/olsrd-utils
   $(call Package/olsrd/template)
-  DEPENDS:=olsrd
+  DEPENDS:=olsrd +jshn
   TITLE:=Utils for OLSRD
 endef
 

--- a/olsrd/Makefile
+++ b/olsrd/Makefile
@@ -177,6 +177,7 @@ endef
 
 MAKE_FLAGS+= \
 	NO_DEBUG_MESSAGES=1 \
+	VERS="$(PKG_VERSION)" \
 	OS="linux" \
 	DESTDIR="$(PKG_INSTALL_DIR)" \
 	STRIP="true" \

--- a/olsrd/files/olsrd-neigh.sh
+++ b/olsrd/files/olsrd-neigh.sh
@@ -50,6 +50,11 @@ read_hostnames()
 					ip="$1"
 					hostname="$2"
 
+					# both values are announced by other nodes in the
+					# mesh, so reject anything that is not a plain
+					# address/hostname before it reaches eval
+					case "$ip$hostname" in *[!A-Za-z0-9.:_-]*) continue ;; esac
+
 					# global vars, e.g.
 					# IP_1_2_3_4='foo' or IP_2001_ffff_ffff_ffff__1='bar'
 					eval IP_${ip//[.:]/_}="$hostname"
@@ -89,6 +94,12 @@ for HOST in '127.0.0.1' '::1';do
 			i=1;while json_is_a ${i} object;do
 				json_select ${i}
 				json_get_vars $(for v in ${VARS};do echo ${v%:*};done)
+
+				# remoteIP is announced by other nodes in the mesh and
+				# is interpolated into a variable name below, so reject
+				# anything that is not a plain address
+				case "$remoteIP" in *[!A-Za-z0-9.:_-]*) remoteIP= ;; esac
+
 				case ${j} in 0)
 					for v in ${VARS};do
 						eval "test \${_${v%:*}} -lt \${#${v%:*}} && _${v%:*}=\${#${v%:*}}"

--- a/olsrd/files/olsrd6.init
+++ b/olsrd/files/olsrd6.init
@@ -46,7 +46,7 @@ start_service() {
 	local _respawn_timeout
 	local _respawn_retry
 
-	config_get _respawn_threshold procd _respawn_threshold 3600
+	config_get _respawn_threshold procd respawn_threshold 3600
 	config_get _respawn_timeout procd respawn_timeout 15
 	config_get _respawn_retry procd respawn_retry 0
 

--- a/olsrd/patches/103-make-set-plugin-SONAME-to-the-installed-filename.patch
+++ b/olsrd/patches/103-make-set-plugin-SONAME-to-the-installed-filename.patch
@@ -1,0 +1,35 @@
+From 11bf26faef5ee6d62a4641407a2f96a97b59db07 Mon Sep 17 00:00:00 2001
+From: Josef Schlehofer <pepe.schlehofer@gmail.com>
+Date: Thu, 6 Aug 2026 09:56:10 +0200
+Subject: [PATCH] make: set plugin SONAME to the installed filename
+
+The plugins are linked with SONAME lib$(PLUGIN_NAME).so, but they are
+installed as $(PLUGIN_NAME).so.$(PLUGIN_VER) and loaded via dlopen()
+using that filename. A library whose SONAME does not match any
+installed filename confuses tooling which verifies that a symlink
+named after the SONAME exists, for example the OpenWrt CI runtime
+tests:
+
+    Library /usr/lib/olsrd_arprefresh.so.0.1 has SONAME
+    'libolsrd_arprefresh.so' but no corresponding symlink was found
+
+Use the full installed filename as SONAME instead. This has no
+functional effect on olsrd itself, since the plugins are dlopen()ed
+by path and never linked against.
+
+Signed-off-by: Josef Schlehofer <pepe.schlehofer@gmail.com>
+---
+ make/Makefile.linux | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/make/Makefile.linux
++++ b/make/Makefile.linux
+@@ -73,7 +73,7 @@ LIBS += -lrt
+ # CPPFLAGS += 	-Dlinux -DLINUX_NETLINK_ROUTING -DLINUX_NL80211
+ # LIBS +=		-lnl
+ 
+-PLUGIN_SONAME ?= lib$(PLUGIN_NAME).so
++PLUGIN_SONAME ?= $(PLUGIN_FULLNAME)
+ PLUGIN_FULLNAME ?= $(PLUGIN_NAME).so.$(PLUGIN_VER)
+ INSTALL_LIB =	install -D -m 755 $(PLUGIN_FULLNAME) $(LIBDIR)/$(PLUGIN_FULLNAME); \
+ 		$(LDCONFIG) -n $(LIBDIR)

--- a/olsrd/src/src/ubus.c
+++ b/olsrd/src/src/ubus.c
@@ -83,6 +83,7 @@ static int olsrd_ubus_add_interface(struct ubus_context *ctx_local,
     double lqm_value = atof(lqm);
     mult->addr = addr;
     mult->value = (uint32_t)(lqm_value * LINK_LOSS_MULTIPLIER);
+    mult->next = tmp_ifs->cnf->lq_mult;
     tmp_ifs->cnf->lq_mult = mult;
     tmp_ifs->cnf->orig_lq_mult_cnt++;
   }

--- a/olsrd/test-version.sh
+++ b/olsrd/test-version.sh
@@ -4,10 +4,7 @@
 
 case "$PKG_NAME" in
 olsrd)
-	# The version of olsrd is derived from the source date and git
-	# hash, which the binary does not report. Check that the binary
-	# starts and prints its version banner instead.
-	olsrd -v 2>&1 | grep -F "olsr.org"
+	olsrd -v 2>&1 | grep -F "$PKG_VERSION"
 	;;
 
 olsrd-mod-*)

--- a/olsrd/test-version.sh
+++ b/olsrd/test-version.sh
@@ -4,6 +4,10 @@
 
 case "$PKG_NAME" in
 olsrd)
+	# olsrd leaves through olsr_exit(), which ends the process with
+	# raise(SIGTERM) even for -v, so the shell reports "Terminated"
+	# after the banner. The pipeline status comes from grep, so the
+	# check is unaffected.
 	olsrd -v 2>&1 | grep -F "$PKG_VERSION"
 	;;
 

--- a/olsrd/test-version.sh
+++ b/olsrd/test-version.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+olsrd)
+	# The version of olsrd is derived from the source date and git
+	# hash, which the binary does not report. Check that the binary
+	# starts and prints its version banner instead.
+	olsrd -v 2>&1 | grep -F "olsr.org"
+	;;
+
+olsrd-mod-*)
+	# Plugins are libraries and do not provide version information
+	exit 0
+	;;
+
+olsrd-utils)
+	# Shell scripts only, no version information provided
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
This fixes the failing CI runtime tests for olsrd, which is part of the fallback test set (`bird2 cjdns olsrd`) used for every PR that does not change any package, so these failures currently make CI red repo-wide.

- The plugins are linked with SONAME `lib$(PLUGIN_NAME).so` but installed as `$(PLUGIN_NAME).so.$(PLUGIN_VER)` without any matching symlink, so the library check of the CI runtime tests failed for all 18 olsrd-mod-* packages. Add a patch setting the SONAME to the installed filename; the plugins are dlopen()ed by path, so this has no functional effect. The patch will also be submitted upstream.
- Add `test-version.sh`: the package version is date+hash based and not reported by any binary, so the generic version check could never pass. Verify the olsrd version banner instead and skip the check for plugin/utility packages.
- Makefile cleanup: remove the MAINTAINER override in the shared template which shadowed PKG_MAINTAINER for all packages, add PKG_LICENSE_FILES, use HTTPS homepage URL.

Maintainer: @PolynomialDivision
