### PR TITLE
bmx7: clean up Makefile and add test-version.sh

### DIFF
--- a/bmx7/Makefile
+++ b/bmx7/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bmx7
 PKG_VERSION:=2024.06.11
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
@@ -30,7 +30,6 @@ MAKE_ARGS += EXTRA_CFLAGS="$(TARGET_CFLAGS) \
 				-DBMX7_LIB_IWINFO" \
 				EXTRA_LDFLAGS="$(TARGET_LDFLAGS) \
 			 	-L$(STAGING_DIR)/usr/lib -liwinfo" \
-				GIT_REV="$(PKG_REV)" \
 				CC="$(TARGET_CC)" \
 				INSTALL_DIR="$(PKG_INSTALL_DIR)" \
 				build_all
@@ -98,7 +97,7 @@ define Package/bmx7-table
 endef
 
 define Package/bmx7/install
-	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/config $(1)/etc/init.d
+	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(MAKE_PATH)/bmx7 $(1)/usr/sbin/bmx7
 endef
 

--- a/bmx7/Makefile
+++ b/bmx7/Makefile
@@ -107,7 +107,7 @@ endef
 
 define Package/bmx7-uci-config/conffiles
 /etc/config/bmx7
-/etc/bmx7
+/etc/bmx7/
 endef
 
 define Package/bmx7-uci-config/install

--- a/bmx7/Makefile
+++ b/bmx7/Makefile
@@ -102,7 +102,7 @@ define Package/bmx7/install
 endef
 
 define Build/Compile
-       $(MAKE) -C $(PKG_BUILD_DIR)/$(MAKE_PATH) $(MAKE_ARGS)
+	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/$(MAKE_PATH) $(MAKE_ARGS)
 endef
 
 define Package/bmx7-uci-config/conffiles

--- a/bmx7/test-version.sh
+++ b/bmx7/test-version.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+bmx7)
+	# The version of bmx7 is derived from the source date, which the
+	# binary does not report. Running `bmx7 -v` is not suitable for
+	# CI either, as it first generates the node RSA key, which can
+	# take a very long time on emulated architectures.
+	exit 0
+	;;
+
+bmx7-*)
+	# Plugins are libraries and do not provide version information
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac

--- a/bmx7/test-version.sh
+++ b/bmx7/test-version.sh
@@ -5,9 +5,10 @@
 case "$PKG_NAME" in
 bmx7)
 	# The version of bmx7 is derived from the source date, which the
-	# binary does not report. Running `bmx7 -v` is not suitable for
-	# CI either, as it first generates the node RSA key, which can
-	# take a very long time on emulated architectures.
+	# binary does not report. `bmx7 -v` is not an alternative: the
+	# key path option is applied before the version option, so a
+	# missing node key gets generated first - "Creating RSA2048
+	# private key. This can take a while", as bmx7 puts it.
 	exit 0
 	;;
 


### PR DESCRIPTION
- Remove `GIT_REV="$(PKG_REV)"` from MAKE_ARGS: PKG_REV is not defined anywhere and the bmx7 build system does not consume a GIT_REV make variable at all.
- Do not create empty /etc/config and /etc/init.d directories in the bmx7 package; the files installed there belong to bmx7-uci-config.
- Add `test-version.sh` for the CI runtime tests: the package version is derived from PKG_SOURCE_DATE, which the binary does not report, so the generic version check could never pass. Running `bmx7 -v` in CI is not suitable either, since it first generates the node RSA-2048 key, which can take very long on emulated architectures.

Maintainer: @axn
