### PR TITLE
babeld: simplify LDLIBS in MAKE_FLAGS

### DIFF
--- a/babeld/Makefile
+++ b/babeld/Makefile
@@ -45,8 +45,7 @@ endef
 
 MAKE_FLAGS+= \
 	CFLAGS="$(TARGET_CFLAGS)" \
-	LDLIBS="" \
-	LDLIBS+="-lubus -lubox"
+	LDLIBS="-lubus -lubox"
 
 define Package/babeld/install
 	$(INSTALL_DIR) $(1)/usr/sbin

--- a/babeld/Makefile
+++ b/babeld/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=babeld
 PKG_VERSION:=1.13.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.irif.fr/~jch/software/files/

--- a/babeld/src/ubus.c
+++ b/babeld/src/ubus.c
@@ -83,7 +83,7 @@ static int babeld_ubus_add_filter(struct ubus_context *ctx_local,
   struct blob_buf b = {0};
   struct filter *filter = NULL;
   char *ifname;
-  int metric, type;
+  int metric = 0, type;
 
   blobmsg_parse(filter_policy, __FILTER_MAX, tb, blob_data(msg), blob_len(msg));
 


### PR DESCRIPTION
Setting LDLIBS to an empty string and appending to it on the same command line is equivalent to assigning the final value directly. No change in the resulting package.

Maintainer: @PolynomialDivision
